### PR TITLE
Changed Luke Scattering rate in G4CMPProcessUtils

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
+2023-08-08  G4CMP-373 : Fix long-standing bug in NTL emission rate.
+
 2023-07-28  g4cmp-V08-04-00 Provide option for more realistic KaplanQP model.
 2023-07-25  G4CMP-325 : Improve physical modeling of absorption in KaplanQP.
 2022-12-09  G4CMP-348 : Remove now-extraneous factor of 2 in EscapeProbability.

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -504,5 +504,5 @@ G4CMPProcessUtils::ChargeCarrierTimeStep(G4double mach, G4double l0) const {
   const G4double velLong = theLattice->GetSoundSpeed();
 
   const G4double tstep = 3.*l0/velLong;
-  return (mach<1.) ? tstep : tstep*mach/((mach-1)*(mach-1)*(mach-1));
+  return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1));
 }

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -505,6 +505,17 @@ G4CMPProcessUtils::ChargeCarrierTimeStep(G4double mach, G4double l0) const {
   const G4double velLong = theLattice->GetSoundSpeed();
 
   const G4double tstep = 3.*l0/velLong;
-  return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1)); // Luke scattering rate = 1/ChargeCarrierTimeStep = 1/(tsep*mach*mach/((mach-1)*(mach-1)*(mach-1))) =  velLong/(3*l0) * kSound^2/kMag^2 * (Kmag/kSound -1)^3 = velLong/(3*l0) * kMag/kSound * (1 - kSound/kMag)^3
+  return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1)); 
+  
+/*  1/Tau = velLong/(3*l0) * kmag/ksound * (1 - ksound/kmag)^3
+          = velLong/(3*l0) * ksound^2/kmag^2 * (kmag/ksound - 1)^3
+          = (1-ksound/kmag)^3 / (3*l0)/velLong) / (kmag^2/ksound^2)
+          = (1-mach)^3 / (tstep * mach^2)
+          = 1 / (tstep * mach^2 * (1/(1-mach)^3)) 
+          = 1/ChargeCarrierTimeStep
+                     
+ChargeCarrierTimeStep= tstep * mach^2 * (1/(1-mach)^3)
+          
+*/
   
 }

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -40,6 +40,7 @@
 // 20201223  Add FindNearestValley() function to align electron momentum.
 // 20210318  In LoadDataForTrack, kill a bad track, not the whole event.
 // 20230524  Expand GetCurrentTouchable() to create one for new tracks
+// 20230807  Multiplied ChargeCarrierTimeStep by mach to get the correct luke scattering rate
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -504,5 +505,6 @@ G4CMPProcessUtils::ChargeCarrierTimeStep(G4double mach, G4double l0) const {
   const G4double velLong = theLattice->GetSoundSpeed();
 
   const G4double tstep = 3.*l0/velLong;
-  return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1));
+  return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1)); // Luke scattering rate = 1/ChargeCarrierTimeStep = 1/(tsep*mach*mach/((mach-1)*(mach-1)*(mach-1))) =  velLong/(3*l0) * kSound^2/kMag^2 * (Kmag/kSound -1)^3 = velLong/(3*l0) * kMag/kSound * (1 - kSound/kMag)^3
+  
 }

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -40,7 +40,9 @@
 // 20201223  Add FindNearestValley() function to align electron momentum.
 // 20210318  In LoadDataForTrack, kill a bad track, not the whole event.
 // 20230524  Expand GetCurrentTouchable() to create one for new tracks
-// 20230807  Multiplied ChargeCarrierTimeStep by mach to get the correct luke scattering rate
+// 20230807  Multiplied ChargeCarrierTimeStep by mach to get the correct
+//		Luke scattering rate
+// 20230808  Added derivation of ChargeCarrierTimeStep to explain bug fix.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -498,7 +500,12 @@ G4int G4CMPProcessUtils::FindNearestValley(G4ThreeVector dir) const {
 
 
 // Compute characteristic time step for charge carrier
-// Parameters are "Mach number" (ratio with sound speed) and scattering length
+// Rate depends on Mach number (v/vsound = k/ksound) and scattering length l0
+// 1/Tau = velLong/(3*l0) * kmag/ksound * (1 - ksound/kmag)^3
+// Tau   = (3*l0)/velLong * 1/mach * (1 - 1/mach)^-3
+//       = (3*l0)/velLong * 1/mach * [(mach-1)/mach]^-3
+//       = (3*l0)/velLong * mach^3/mach * (mach-1)^-3
+//       = (3*l0)/velLong * mach^2 / (mach-1)^3
 
 G4double 
 G4CMPProcessUtils::ChargeCarrierTimeStep(G4double mach, G4double l0) const {
@@ -506,16 +513,4 @@ G4CMPProcessUtils::ChargeCarrierTimeStep(G4double mach, G4double l0) const {
 
   const G4double tstep = 3.*l0/velLong;
   return (mach<1.) ? tstep : tstep*mach*mach/((mach-1)*(mach-1)*(mach-1)); 
-  
-/*  1/Tau = velLong/(3*l0) * kmag/ksound * (1 - ksound/kmag)^3
-          = velLong/(3*l0) * ksound^2/kmag^2 * (kmag/ksound - 1)^3
-          = (1-ksound/kmag)^3 / (3*l0)/velLong) / (kmag^2/ksound^2)
-          = (1-mach)^3 / (tstep * mach^2)
-          = 1 / (tstep * mach^2 * (1/(1-mach)^3)) 
-          = 1/ChargeCarrierTimeStep
-                     
-ChargeCarrierTimeStep= tstep * mach^2 * (1/(1-mach)^3)
-          
-*/
-  
 }


### PR DESCRIPTION
In G4CMPProcessUtils, multiplied line 472 by mach to get the correct Luke scattering rate.