### PR TITLE
G4 cmp 381

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,9 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
+2023-08-31  G4CMP-381 : Compute rotation matrices from valley's direction
+			instead of Euler angles. Add anti-valleys.
+
 2023-08-31  g4cmp-V08-04-01 Revert two recent changes to restore NTL energy.
 2023-08-31  G4CMP-380 : Withdraw G4CMP-373, causes zero-length/NaN steps.
 2023-08-24  G4CMP-377 : Withdraw G4CMP-359/360, retstore energy conservation.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,8 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
-2023-08-31  G4CMP-381 : Compute rotation matrices from valley's direction
-			instead of Euler angles. Add anti-valleys.
+2023-08-31  G4CMP-381 : Add valleys and anti-valleys from Miller indices.
 
 2023-08-31  g4cmp-V08-04-01 Revert two recent changes to restore NTL energy.
 2023-08-31  G4CMP-380 : Withdraw G4CMP-373, causes zero-length/NaN steps.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
+2023-08-31  g4cmp-V08-04-01 Revert two recent changes to restore NTL energy.
 2023-08-31  G4CMP-380 : Withdraw G4CMP-373, causes zero-length/NaN steps.
 2023-08-24  G4CMP-377 : Withdraw G4CMP-359/360, retstore energy conservation.
 2023-08-08  G4CMP-373 : Fix long-standing bug in NTL emission rate.

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
-2023-08-31  G4CMP-381 : Add valleys and anti-valleys from Miller indices.
+2023-11-22  G4CMP-375 : Remove 50% momentum flip in G4CMPInterValleyScattering.
+2023-11-10  G4CMP-381 : Add valleys and anti-valleys from Miller indices.
 
 2023-08-31  g4cmp-V08-04-01 Revert two recent changes to restore NTL energy.
 2023-08-31  G4CMP-380 : Withdraw G4CMP-373, causes zero-length/NaN steps.

--- a/CrystalMaps/Ge/config.txt
+++ b/CrystalMaps/Ge/config.txt
@@ -28,6 +28,10 @@ valley  -45 35.2644 90 deg
 valley   45 35.2644 90 deg
 valley  135 35.2644 90 deg
 valley -135 35.2644 90 deg
+valleyDir 1 1 1 
+valleyDir -1 1 1
+valleyDir -1 -1 1
+valleyDir 1 -1 1
 # Intervalley scattering (matrix elements)
 alpha 0.3 /eV
 acDeform 11 eV

--- a/CrystalMaps/Ge/config.txt
+++ b/CrystalMaps/Ge/config.txt
@@ -24,10 +24,6 @@ l0_h 108 um
 #hole and electron masses taken from Robert's thesis
 hmass 0.350		# per m(electron)
 emass 1.588 0.081 0.081	# per m(electron)
-#valley  -45 35.2644 90 deg
-#valley   45 35.2644 90 deg
-#valley  135 35.2644 90 deg
-#valley -135 35.2644 90 deg
 valleyDir 1 1 1 
 valleyDir -1 1 1
 valleyDir -1 -1 1

--- a/CrystalMaps/Ge/config.txt
+++ b/CrystalMaps/Ge/config.txt
@@ -24,10 +24,10 @@ l0_h 108 um
 #hole and electron masses taken from Robert's thesis
 hmass 0.350		# per m(electron)
 emass 1.588 0.081 0.081	# per m(electron)
-valley  -45 35.2644 90 deg
-valley   45 35.2644 90 deg
-valley  135 35.2644 90 deg
-valley -135 35.2644 90 deg
+#valley  -45 35.2644 90 deg
+#valley   45 35.2644 90 deg
+#valley  135 35.2644 90 deg
+#valley -135 35.2644 90 deg
 valleyDir 1 1 1 
 valleyDir -1 1 1
 valleyDir -1 -1 1

--- a/CrystalMaps/Si/config.txt
+++ b/CrystalMaps/Si/config.txt
@@ -24,9 +24,9 @@ l0_h 7.5e-5 m
 #hole and electron masses taken from Robert's thesis
 hmass 0.50		# per m(electron)
 emass 0.91 0.19 0.19	# per m(electron)
-valley   0  0  0 deg
-valley   90 90 0 deg
-valley   0 -90 -90 deg
+#valley   0  0  0 deg
+#valley   90 90 0 deg
+#valley   0 -90 -90 deg
 valleyDir 1 0 0 
 valleyDir 0 1 0 
 valleyDir 0 0 1

--- a/CrystalMaps/Si/config.txt
+++ b/CrystalMaps/Si/config.txt
@@ -27,6 +27,9 @@ emass 0.91 0.19 0.19	# per m(electron)
 valley   0  0  0 deg
 valley   90 90 0 deg
 valley   0 -90 -90 deg
+valleyDir 1 0 0 
+valleyDir 0 1 0 
+valleyDir 0 0 1
 # Intervalley scattering (matrix elements)
 alpha 0.5 /eV
 acDeform 6.6 eV

--- a/CrystalMaps/Si/config.txt
+++ b/CrystalMaps/Si/config.txt
@@ -24,9 +24,6 @@ l0_h 7.5e-5 m
 #hole and electron masses taken from Robert's thesis
 hmass 0.50		# per m(electron)
 emass 0.91 0.19 0.19	# per m(electron)
-#valley   0  0  0 deg
-#valley   90 90 0 deg
-#valley   0 -90 -90 deg
 valleyDir 1 0 0 
 valleyDir 0 1 0 
 valleyDir 0 0 1

--- a/library/include/G4LatticeLogical.hh
+++ b/library/include/G4LatticeLogical.hh
@@ -38,7 +38,7 @@
 //		precompute valley inverse transforms
 // 20200608  Fix -Wshadow warnings from tempvec
 // 20210919  M. Kelsey -- Allow SetVerboseLevel() from const instances.
-// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' to compute rotation matrix from valley's direction
+// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' 
 
 #ifndef G4LatticeLogical_h
 #define G4LatticeLogical_h
@@ -208,7 +208,7 @@ public:
   // Transform for drifting-electron valleys in momentum space
   void AddValley(const G4RotationMatrix& valley);
   void AddValley(G4double phi, G4double theta, G4double psi);
-  void AddValley(const G4ThreeVector&);
+  void AddValley(const G4ThreeVector&, G4bool antival=false);
   void ClearValleys() {
     fValley.clear(); fValleyInv.clear();fValleyAxis.clear();
   }

--- a/library/include/G4LatticeLogical.hh
+++ b/library/include/G4LatticeLogical.hh
@@ -38,6 +38,7 @@
 //		precompute valley inverse transforms
 // 20200608  Fix -Wshadow warnings from tempvec
 // 20210919  M. Kelsey -- Allow SetVerboseLevel() from const instances.
+// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' to compute rotation matrix from valley's direction
 
 #ifndef G4LatticeLogical_h
 #define G4LatticeLogical_h
@@ -207,6 +208,7 @@ public:
   // Transform for drifting-electron valleys in momentum space
   void AddValley(const G4RotationMatrix& valley);
   void AddValley(G4double phi, G4double theta, G4double psi);
+  void AddValley(const G4ThreeVector&);
   void ClearValleys() {
     fValley.clear(); fValleyInv.clear();fValleyAxis.clear();
   }

--- a/library/include/G4LatticeReader.hh
+++ b/library/include/G4LatticeReader.hh
@@ -67,6 +67,7 @@ protected:
   G4bool ProcessDebyeLevel();			// Frequency or temperature
   G4bool ProcessStiffness();			// Elasticity matrix element
   G4bool ProcessEulerAngles(const G4String& name);	// Drift directions
+  G4bool ProcessValleyDirection();	// Drift directions
   G4bool ProcessDeformation();			// IV deformation potentials
   G4bool ProcessThresholds();			// IV energy thresholds
   G4bool SkipComments();			// Everything after '#'

--- a/library/include/G4LatticeReader.hh
+++ b/library/include/G4LatticeReader.hh
@@ -22,6 +22,7 @@
 // 20170525  Implement 'rule of five' with default copy/move semantics
 // 20170810  Add utility function to process list of values with unit.
 // 20190704  Add utility function to process string/name argument
+// 20231102  Add ProcessValleyDirection()
 
 #ifndef G4LatticeReader_h
 #define G4LatticeReader_h 1
@@ -67,7 +68,7 @@ protected:
   G4bool ProcessDebyeLevel();			// Frequency or temperature
   G4bool ProcessStiffness();			// Elasticity matrix element
   G4bool ProcessEulerAngles(const G4String& name);	// Drift directions
-  G4bool ProcessValleyDirection();	// Drift directions
+  G4bool ProcessValleyDirection();		// Drift directions
   G4bool ProcessDeformation();			// IV deformation potentials
   G4bool ProcessThresholds();			// IV energy thresholds
   G4bool SkipComments();			// Everything after '#'

--- a/library/src/G4CMPInterValleyScattering.cc
+++ b/library/src/G4CMPInterValleyScattering.cc
@@ -25,6 +25,7 @@
 // 20190704  Add selection of rate model by name, and material specific
 // 20190904  C. Stanford -- Add 50% momentum flip (see G4CMP-168)
 // 20190906  Push selected rate model back to G4CMPTimeStepper for consistency
+// 20231122  Remove 50% momentum flip (see G4CMP-375)
 
 #include "G4CMPInterValleyScattering.hh"
 #include "G4CMPConfigManager.hh"
@@ -130,11 +131,6 @@ G4CMPInterValleyScattering::PostStepDoIt(const G4Track& aTrack,
   p = theLattice->MapK_valleyToP(valley, p); // p is p again
   RotateToGlobalDirection(p);
   
-  // There's a 50% chance that the charge jumped into the antivalley rather
-  // than the primary valley. If so, its momentum needs to be reversed to 
-  // preserve symmetry.
-  if (G4UniformRand()>0.5) p = -p;
-
   // Adjust track kinematics for new valley
   FillParticleChange(valley, p);
   

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -45,6 +45,7 @@
 // 20230808  Added derivation of ChargeCarrierTimeStep to explain bug fix.
 // 20230831  Remove modifications to ChargeCarrierTimeStep(), they seem to
 //		cause zero-length and NaN steps.
+// 20231207  Remove fabs in FindNearestValley.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -487,7 +488,7 @@ G4int G4CMPProcessUtils::FindNearestValley(G4ThreeVector dir) const {
   std::set<G4int> bestValley;	// Collect all best matches for later choice
   G4double align, bestAlign = -1.;
   for (size_t i=0; i<theLattice->NumberOfValleys(); i++) {
-    align = fabs(theLattice->GetValleyAxis(i).dot(dir)); // Both unit vectors
+    align = theLattice->GetValleyAxis(i).dot(dir); // Both unit vectors
     if (align > bestAlign) {
       bestValley.clear();
       bestAlign = align;

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -703,32 +703,33 @@ void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec) {
    double c=0;
    double d;
    double e;
+   double f;
     
    if (vx==0 && vy==0){
-       e=0;
+       f=0;
        b=1;
-       a=1;
+       a=0;
    }
    
    else {
-       e=sqrt(1-vz*vz);
-       b=vx/e;
-       a=-vy/e;
+       f=sqrt(1-vz*vz);
+       b=vx/f;
+       a=-vy/f;
    }
      
    d=-vz*b;
    e=vz*a;
    
-G4cout << "test12 : " << a << " " << b << " " << c << " " << d << " " << e << G4endl;
+G4cout << "test12 : " << a << " " << b << " " << c << " " << d << " " << e << " " << G4endl;
     
-//     G4ThreeVector colx(1,0,0);
-//     G4ThreeVector coly(0,1,0);
-//     G4ThreeVector colz(0,0,1);
+    G4ThreeVector colx(vx,vy,vz);
+    G4ThreeVector coly(a,b,c);
+    G4ThreeVector colz(d,e,f);
 //     //HepRep3x3 test1(aa,aa,aa,aa,aa,aa,aa,aa,aa);
-//     G4RotationMatrix test1(colx,coly,colz);
+    G4RotationMatrix test1(colx,coly,colz);
     
     
-//   G4cout << "test : " << test1 <<  G4endl;
+  G4cout << "test : " << test1 <<  G4endl;
     
 }
 

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -694,16 +694,22 @@ void G4LatticeLogical::AddValley(G4double phi, G4double theta, G4double psi) {
 // Store drifting-electron valley using valley's direction
 
 void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec) {
+    
+   
       
-   double vx=valleyDirVec.x();
-   double vy=valleyDirVec.y();
-   double vz=valleyDirVec.z();
-   double a;
-   double b;
-   double c=0;
-   double d;
-   double e;
-   double f;
+   long double vx=valleyDirVec.x();
+   long double vy=valleyDirVec.y();
+   long double vz=valleyDirVec.z();
+   long double normval=sqrt(vx*vx+vy*vy+vz*vz);
+   vx=vx/normval;
+   vy=vy/normval;
+   vz=vz/normval;
+   long double a;
+   long double b;
+   long double c=0;
+   long double d;
+   long double e;
+   long double f;
     
    if (vx==0 && vy==0){
        f=0;
@@ -722,9 +728,9 @@ void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec) {
    
 G4cout << "test12 : " << a << " " << b << " " << c << " " << d << " " << e << " " << G4endl;
     
-    G4ThreeVector colx(vx,vy,vz);
-    G4ThreeVector coly(a,b,c);
-    G4ThreeVector colz(d,e,f);
+    G4ThreeVector colx(vx,a,d);
+    G4ThreeVector coly(vy,b,e);
+    G4ThreeVector colz(vz,c,f);
 //     //HepRep3x3 test1(aa,aa,aa,aa,aa,aa,aa,aa,aa);
     G4RotationMatrix test1(colx,coly,colz);
     

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -44,6 +44,7 @@
 // 20190906  M. Kelsey -- Default IV rate model to G4CMPConfigManager value.
 // 20200520  For MT thread safety, wrap G4ThreeVector buffer in function to
 //		return thread-local instance.
+// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' to compute rotation matrix from valley's direction
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****
@@ -688,6 +689,47 @@ void G4LatticeLogical::AddValley(G4double phi, G4double theta, G4double psi) {
 
   // NOTE:  Rotation matrices take external vector along valley axis to X-hat
   fValleyAxis.push_back(fValleyInv.back()*G4ThreeVector(1.,0.,0.));
+}
+
+// Store drifting-electron valley using valley's direction
+
+void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec) {
+      
+   double vx=valleyDirVec.x();
+   double vy=valleyDirVec.y();
+   double vz=valleyDirVec.z();
+   double a;
+   double b;
+   double c=0;
+   double d;
+   double e;
+    
+   if (vx==0 && vy==0){
+       e=0;
+       b=1;
+       a=1;
+   }
+   
+   else {
+       e=sqrt(1-vz*vz);
+       b=vx/e;
+       a=-vy/e;
+   }
+     
+   d=-vz*b;
+   e=vz*a;
+   
+G4cout << "test12 : " << a << " " << b << " " << c << " " << d << " " << e << G4endl;
+    
+//     G4ThreeVector colx(1,0,0);
+//     G4ThreeVector coly(0,1,0);
+//     G4ThreeVector colz(0,0,1);
+//     //HepRep3x3 test1(aa,aa,aa,aa,aa,aa,aa,aa,aa);
+//     G4RotationMatrix test1(colx,coly,colz);
+    
+    
+//   G4cout << "test : " << test1 <<  G4endl;
+    
 }
 
 // Store rotation matrix and corresponding axis vector for valley

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -688,12 +688,7 @@ void G4LatticeLogical::AddValley(G4double phi, G4double theta, G4double psi) {
   fValleyInv.back().invert();
 
   // NOTE:  Rotation matrices take external vector along valley axis to X-hat
-  fValleyAxis.push_back(fValleyInv.back()*G4ThreeVector(1.,0.,0.));
-   
-for (int i = 0; i < 8; i++) {
-    G4cout << "valley : " << fValley[i] << G4endl;
-}
-    
+  fValleyAxis.push_back(fValleyInv.back()*G4ThreeVector(1.,0.,0.));    
 }
 
 // Store drifting-electron valley using valley's direction

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -44,7 +44,7 @@
 // 20190906  M. Kelsey -- Default IV rate model to G4CMPConfigManager value.
 // 20200520  For MT thread safety, wrap G4ThreeVector buffer in function to
 //		return thread-local instance.
-// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' to compute rotation matrix from valley's direction
+// 20231017  E. Michaud -- Add 'AddValley(const G4ThreeVector&)' 
 
 #include "G4LatticeLogical.hh"
 #include "G4CMPPhononKinematics.hh"	// **** THIS BREAKS G4 PORTING ****
@@ -693,144 +693,105 @@ void G4LatticeLogical::AddValley(G4double phi, G4double theta, G4double psi) {
 
 // Store drifting-electron valley using valley's direction
 
-void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec) {
+void G4LatticeLogical::AddValley(const G4ThreeVector& valleyDirVec, G4bool antival) {
       
   // Find the rotation matrix elements. 
-  // The rows correspond to the rotated axis direction (first row is vx,vy,vz ; second row is a,b,c and third row is d,e,f)
+  // The rows correspond to the rotated axis direction 
+  // First row is vx,vy,vz ; second row is a,b,c and third row is d,e,f
     
-  // The convention used does not affect HV-transformation. For simplicity, we choose the following conditions :
-  // The rotated y axis must stay in the X-Y plane (c=0)
-  // The rotate Z axis must have positive z component (f>0) 
-  // The three rotated axis should stay normalized : vx^2 + vy^2 + vz^2 = 1 ; a^2 + b^2 = 1 ; d^2 + e^2 + f^2 = 1
-  // And be orthogonal : ad + be = 0 ; avx + bvy = 0 ; dvx + evy + fvz = 0
-  // It must be a right hand coordinate system : (vx,vy,vz) X (a,b,c) = (d,e,f) : d=-vzb ; e=vza ; f=vxb - vya
+  // We chose the following convention :
+  //  - The rotated y axis must stay in the X-Y plane (c=0)
+  //  - Valley's rotated Z axis must have positive z component (f>0) 
+  //  - Anti-valley's rotated Z axis must have positive z component (f>0) 
+  //  - The three rotated axis should stay normalized :
+  //	vx^2 + vy^2 + vz^2 = 1 ; a^2 + b^2 = 1 ; d^2 + e^2 + f^2 = 1
+  //  - And be orthogonal :
+  //	ad + be = 0 ; avx + bvy = 0 ; dvx + evy + fvz = 0
+  //  - It must be a right hand coordinate system :
+  //	(vx,vy,vz) X (a,b,c) = (d,e,f) : d=-vzb ; e=vza ; f=vxb - vya
     
-  // We first compute f since it needs to be positive and will therefore clear out signs ambiguity 
+  // We first compute f 
   // d^2 + e^2 + f^2 = 1
   // f^2 = 1 - d^2 - e^2
   // f^2 = 1 - vz^2 b^2 - vz^2 a^2
   // f^2 = 1 - vz^2 (b^2 + a^2)
   // f^2 = 1 - vz^2
-  // f = + sqrt(1 - vz^2)
-    
-    
-  // Then we compute special cases first (vx and vy=0, vx=0 but not vy and vy=0 but not vx).
-    
-  // We start with vx= and vy=0
-  // e=0 and there is only two possible rotation matrix since vz=1 or -1. We manually set the elements to :
-  // b=1 
-  // a=0
-    
-  // If vx=0 but not vy 
-  // a = -e/vy = -sqrt(1-vz^2)/vy = -sqrt(vy^2)/vy = -1 for valleys and 1 for anti-valleys
-  // b=0
+  // f = +- sqrt(1 - vz^2)
 
-  // If vy=0 but not vx 
-  // b = e/vx = sqrt(1-vz^2)/vx = sqrt(vx^2)/vx = 1 for valleys and -1 for anti-valleys
-  // a=0
-    
-    
-  // We go on with "general case" where  vx=!0 and vy!=0
-    
-  // We start by computing b (if vx=!0 and vy!=0) : 
+  // We compute b (if vx=!0 and vy!=0) : 
   // f = vxb - vya
   // f = vxb - vy (-bvy/vx)
-  // f = b(vx + vy^2/vx)
   // f = b/vx(vx^2 + vy^2)
   // b = fvx/(vx^2 + vy^2)
   // b = fvx/(1 - vz^2)
-  // b = fvx/f^2
   // b = vx/f
     
   // Then we compute a (if vx=!0 and vx!=0) : 
   // a = -bvy/vx
   // a = -vxvy/e/vx
   // a = -vy/e
-    
-    
-  // Finally, we compute d and e which is the same for every case :
+
+  // Finally, we compute d and e :
   // d=-vzb
-  // e=vza
+  // e=vza 
     
+  // If vx=0 and/or vy=0, we compute a and b differently.
+
+  tempvec()=valleyDirVec.unit();
     
-  double vx=valleyDirVec.x();
-  double vy=valleyDirVec.y();
-  double vz=valleyDirVec.z();
-  double normval=sqrt(vx*vx+vy*vy+vz*vz); 
-  vx=vx/normval;
-  vy=vy/normval;
-  vz=vz/normval;
+  double vx=tempvec().x();
+  double vy=tempvec().y();
+  double vz=tempvec().z();
+  
   double a;
   double b;
   double c=0; // rotated y axis must stay in the X-Y plane
   double d;
   double e;
   double f;
-  double antia; // find the corresponding anti-valley rotation matrix elements
-  double antib;
-  double antid;
-  double antie;
-   
-  f=sqrt(1-vz*vz); // we ask rotated z axis to point in the +z direction so we take +sqrt()
+
+  // rotated z axis points in the +z direction for valleys  
+  f=sqrt(1-vz*vz); 
+    
+  // rotated z axis points in the -z direction for anti-valleys  
+  if (antival==true) {f*=-1;}
+    
     
   if (vx==0 && vy==0){ // special case if vx=vy=0
       b=1;
       a=0;
-      antib=1;
-      antia=0;
   }
    
   else if (vx==0){ // special case if vx=0 but not vy
       a=-1;
       b=0;
-      antia=1;
-      antib=0;
-      
   }
     
-  else if (vy==0){ // special case if vy= bu not vx
+  else if (vy==0){ // special case if vy=0 but not vx
       a=0;
-      b=1;
-      antia=0;
-      antib=-1;
-      
+      b=1;    
   }
     
   else {  
       b=vx/f;
       a=-vy/f;
-      antib=-vx/f;
-      antia=vy/f;
   }
      
   d=-vz*b;
   e=vz*a;
-  antid=vz*antib;
-  antie=-vz*antia;
-   
-  // Store the valley's rotation matrix columns
-  G4ThreeVector colx(vx,a,d);
-  G4ThreeVector coly(vy,b,e);
-  G4ThreeVector colz(vz,c,f);
-    
-  // Store the anti-valley's rotation matrix columns 
-  G4ThreeVector anticolx(-vx,antia,antid);
-  G4ThreeVector anticoly(-vy,antib,antie);
-  G4ThreeVector anticolz(-vz,c,f); 
-    
+
+  G4Rep3x3 M;
+  M = G4Rep3x3( vx,vy, vz, 
+	a, b, c, 
+	d, e, f );
+      
   // Store the valley's rotation matrix, its inverse and the valley's direction.
   fValley.resize(fValley.size()+1);
-  fValley.back().set(colx,coly,colz);
+  fValley.back().set(M);
   fValleyInv.push_back(fValley.back());
   fValleyInv.back().invert();
-  fValleyAxis.push_back(valleyDirVec/normval);
-    
-  // Store the corresponding anti-valley's rotation matrix, its inverse and the anti-valley's direction. 
-  fValley.resize(fValley.size()+1);
-  fValley.back().set(anticolx,anticoly,anticolz);
-  fValleyInv.push_back(fValley.back());
-  fValleyInv.back().invert();
-  fValleyAxis.push_back(-valleyDirVec/normval);    
+  fValleyAxis.push_back(tempvec());
+   
 }
 
 // Store rotation matrix and corresponding axis vector for valley

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -32,7 +32,8 @@
 // 20180815  F. Insulla -- Added IVRateQuad
 // 20181001  M. Kelsey -- Clarify IV rate parameters systematically
 // 20190704  M. Kelsey -- Add 'ivModel' to set default IV function by material
-// 20231017  E. Michaud -- Add 'valleyDir' to set rotation matrix with valley's direction instead of euler angles
+// 20231017  E. Michaud -- Add 'valleyDir' to set rotation matrix with valley's 
+//		 direction instead of euler angles
 
 #include "G4LatticeReader.hh"
 #include "G4CMPConfigManager.hh"
@@ -147,7 +148,7 @@ G4bool G4LatticeReader::ProcessToken() {
       fToken == "cij")      return ProcessStiffness();  // Elasticity element
   if (fToken == "emass")    return ProcessMassTensor();	// e- mass eigenvalues
   if (fToken == "valley")   return ProcessEulerAngles(fToken); // e- drift dirs
-  if (fToken == "valleydir")   return ProcessValleyDirection(); // miller indices valley dirs
+  if (fToken == "valleydir")return ProcessValleyDirection(); // miller indices valley dirs
   if (fToken == "debye")    return ProcessDebyeLevel(); // Freq or temperature
   if (fToken == "ivdeform") return ProcessDeformation(); // D0, D1 potentials
   if (fToken == "ivenergy") return ProcessThresholds();  // D0, D1 Emin
@@ -394,6 +395,7 @@ G4bool G4LatticeReader::ProcessEulerAngles(const G4String& name) {
     G4cerr << "G4LatticeReader: Unknown rotation matrix " << name << G4endl;
     return false;
   }
+    
   G4double degOrRad = ProcessUnits("Angle");
   pLattice->AddValley(phi*degOrRad, theta*degOrRad, psi*degOrRad);
   return psLatfile->good();
@@ -411,6 +413,7 @@ G4bool G4LatticeReader::ProcessValleyDirection() {
 
   G4ThreeVector valleyDirVec(milleri,millerj,millerk);
   pLattice->AddValley(valleyDirVec);
+  pLattice->AddValley(-valleyDirVec,true);
   return psLatfile->good();
 }
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -32,6 +32,7 @@
 // 20180815  F. Insulla -- Added IVRateQuad
 // 20181001  M. Kelsey -- Clarify IV rate parameters systematically
 // 20190704  M. Kelsey -- Add 'ivModel' to set default IV function by material
+// 20231017  E. Michaud -- Add 'valleyDir' to set rotation matrix with valley's direction instead of euler angles
 
 #include "G4LatticeReader.hh"
 #include "G4CMPConfigManager.hh"
@@ -146,6 +147,7 @@ G4bool G4LatticeReader::ProcessToken() {
       fToken == "cij")      return ProcessStiffness();  // Elasticity element
   if (fToken == "emass")    return ProcessMassTensor();	// e- mass eigenvalues
   if (fToken == "valley")   return ProcessEulerAngles(fToken); // e- drift dirs
+  if (fToken == "valleydir")   return ProcessValleyDirection(); // miller indices valley dirs
   if (fToken == "debye")    return ProcessDebyeLevel(); // Freq or temperature
   if (fToken == "ivdeform") return ProcessDeformation(); // D0, D1 potentials
   if (fToken == "ivenergy") return ProcessThresholds();  // D0, D1 Emin
@@ -392,11 +394,26 @@ G4bool G4LatticeReader::ProcessEulerAngles(const G4String& name) {
     G4cerr << "G4LatticeReader: Unknown rotation matrix " << name << G4endl;
     return false;
   }
-
   G4double degOrRad = ProcessUnits("Angle");
   pLattice->AddValley(phi*degOrRad, theta*degOrRad, psi*degOrRad);
   return psLatfile->good();
 }
+
+
+// Read miller indices (milleri, millerj, millerk) for named rotation matrix
+
+G4bool G4LatticeReader::ProcessValleyDirection() {
+  G4double milleri=0., millerj=0., millerk=0.;
+  *psLatfile >> milleri >> millerj >> millerk;
+  if (verboseLevel>1)
+    G4cout << " ProcessValleyDirection "  << milleri << " " 
+	   << millerj << " " << millerk << G4endl;
+
+  G4ThreeVector valleyDirVec(milleri,millerj,millerk);
+  pLattice->AddValley(valleyDirVec);
+  return psLatfile->good();
+}
+
 
 // Read deformation potentials and thresholds for IV scattering
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -399,7 +399,7 @@ G4bool G4LatticeReader::ProcessEulerAngles(const G4String& name) {
   G4double degOrRad = ProcessUnits("Angle");
   pLattice->AddValley(phi*degOrRad, theta*degOrRad, psi*degOrRad);
   // Anti-valleys
-  pLattice->AddValley(phi*degOrRad+pi, -1*(theta*degOrRad+pi), -psi*degOrRad);
+  pLattice->AddValley(phi*degOrRad+pi, -theta*degOrRad+pi, -psi*degOrRad);
   return psLatfile->good();
 }
 

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -398,6 +398,8 @@ G4bool G4LatticeReader::ProcessEulerAngles(const G4String& name) {
     
   G4double degOrRad = ProcessUnits("Angle");
   pLattice->AddValley(phi*degOrRad, theta*degOrRad, psi*degOrRad);
+  // Anti-valleys
+  pLattice->AddValley(phi*degOrRad+pi, -1*(theta*degOrRad+pi), -psi*degOrRad);
   return psLatfile->good();
 }
 


### PR DESCRIPTION
Implement a method to find rotation matrix (both valleys and anti-valleys) from miller indices instead of Euler angles. Theses changes solves some of the problems from JIRA ticket : 
-G4CMP-382 (store anti-valleys)
-G4CMP-381 (rounding errors in Euler angles methods)
-G4CMP-375 (how IV scattering must use anti-valleys instead of multiplying by -1 50% of the time) 
-G4CMP-374 (Si rotation matrices convention)
-G4CMP-338 (Ge rotation matrices convention)

Need to looks at G4CMP-375 more specifically since the convention used may affect momentum after IV scattering.