### PR TITLE
removed the 50% momentum flip

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
-2023-08-31  G4CMP-381 : Add valleys and anti-valleys from Miller indices.
+2023-11-22  G4CMP-375 : Remove 50% momentum flip in G4CMPInterValleyScattering.
+2023-11-10  G4CMP-381 : Add valleys and anti-valleys from Miller indices.
 
 2023-08-31  g4cmp-V08-04-01 Revert two recent changes to restore NTL energy.
 2023-08-31  G4CMP-380 : Withdraw G4CMP-373, causes zero-length/NaN steps.

--- a/library/src/G4CMPInterValleyScattering.cc
+++ b/library/src/G4CMPInterValleyScattering.cc
@@ -25,6 +25,7 @@
 // 20190704  Add selection of rate model by name, and material specific
 // 20190904  C. Stanford -- Add 50% momentum flip (see G4CMP-168)
 // 20190906  Push selected rate model back to G4CMPTimeStepper for consistency
+// 20231122  Remove 50% momentum flip (see G4CMP-375)
 
 #include "G4CMPInterValleyScattering.hh"
 #include "G4CMPConfigManager.hh"
@@ -130,11 +131,6 @@ G4CMPInterValleyScattering::PostStepDoIt(const G4Track& aTrack,
   p = theLattice->MapK_valleyToP(valley, p); // p is p again
   RotateToGlobalDirection(p);
   
-  // There's a 50% chance that the charge jumped into the antivalley rather
-  // than the primary valley. If so, its momentum needs to be reversed to 
-  // preserve symmetry.
-  if (G4UniformRand()>0.5) p = -p;
-
   // Adjust track kinematics for new valley
   FillParticleChange(valley, p);
   


### PR DESCRIPTION
Removed the 50% momentum flip in G4CMPInterValleyScattering since we are now using anti-valleys instead of only using valleys and multiplying momentum by -1 50% of the time to account for anti-valleys.