### PR TITLE
G4CMP 369

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,6 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn".
 
 [ Modifications included on branch G4CMP-276: ]
+2024-02-07  G4CMP-369 : Adapting Luke Scattering with the new kinematics.
+	    Modifications to mfp.
 2023-07-02  G4CMP-352 : Correct physics of band structure in EqEMField and
             LatticeLogical. Introduce quasi-momentum p_Q.
 2023-02-10  G4CMP-352 : Use relativistic expressions for MapPtoEkin, electron mass.

--- a/library/include/G4CMPVDriftProcess.hh
+++ b/library/include/G4CMPVDriftProcess.hh
@@ -46,6 +46,12 @@ protected:
   void FillParticleChange(G4int ivalley, G4double Ekin,
               const G4ThreeVector& v);
 
+  // Initializing ParticleChange and setting up the correct energy and
+  // effective for the charge carrier
+  void InitializeParticleChange(G4int ivalley, const G4Track& track);
+
+  G4double currentEkin;	// Caching the current track kinetic energy
+
 private:
   // hide assignment operators as private 
   G4CMPVDriftProcess(G4CMPVDriftProcess&);

--- a/library/src/G4CMPEqEMField.cc
+++ b/library/src/G4CMPEqEMField.cc
@@ -130,11 +130,7 @@ void G4CMPEqEMField::EvaluateRhsGivenB(const G4double y[],
   fGlobalToLocal.ApplyAxisTransform(mom);
   G4double Energy = theLattice->MapPtoEkin(valleyIndex,mom) + electron_mass_c2;
   vel = mom;
-<<<<<<< HEAD
-  vel /=sqrt(mom.mag2() + fMass*fMass)/c_light; // v=pc^2/E = (gamma mvc^2) / (gamma mc^2) = v
-=======
   vel *= c_light/Energy;		// v = pc^2/E
->>>>>>> G4CMP-352-TEMP
   G4double vinv = 1./vel.mag();
 
 #ifdef G4CMP_DEBUG

--- a/library/src/G4CMPLukeEmissionRate.cc
+++ b/library/src/G4CMPLukeEmissionRate.cc
@@ -33,25 +33,21 @@ G4double G4CMPLukeEmissionRate::Rate(const G4Track& aTrack) const {
     return 0.;
   }
 
-  G4double kmag = 0.; G4double l0 = 0.; G4double mass = 0.;
+  G4double vmag = 0.; G4double l0 = 0.;
+  vmag = GetLocalVelocityVector(aTrack).mag();
   if (G4CMP::IsElectron(aTrack)) {
-    kmag = theLattice->MapV_elToK_HV(GetValleyIndex(aTrack),
-				     GetLocalVelocityVector(aTrack)).mag();
     l0 = theLattice->GetElectronScatter();
-    mass = theLattice->GetElectronMass();	// Scalar mass
   } else if (G4CMP::IsHole(aTrack)) {
-    kmag = GetLocalWaveVector(aTrack).mag();
     l0 = theLattice->GetHoleScatter();
-    mass = theLattice->GetHoleMass();
   }
 
   if (verboseLevel > 1) 
-    G4cout << "LukeEmissionRate kmag = " << kmag*m << " /m" << G4endl;
+    G4cout << "LukeEmissionRate vmag = " << vmag/(m/s) << " m/s" << G4endl;
 
-  G4double kSound = theLattice->GetSoundSpeed() * mass / hbar_Planck;
+  G4double vsound = theLattice->GetSoundSpeed();
 
   // Time step corresponding to Mach number (avg. time between radiations)
-  return (kmag > kSound) ? 1./ChargeCarrierTimeStep(kmag/kSound, l0) : 0.;
+  return (vmag > vsound) ? 1./ChargeCarrierTimeStep(vmag/vsound, l0) : 0.;
 }
 
 
@@ -63,7 +59,12 @@ G4double G4CMPLukeEmissionRate::Threshold(G4double Eabove) const {
   G4ThreeVector vtrk = GetLocalVelocityVector(trk);
   G4double vsound = theLattice->GetSoundSpeed();
   G4ThreeVector v_el = vsound * vtrk.unit();
-  G4double Esound = theLattice->MapV_elToEkin(GetValleyIndex(trk), v_el);
+  G4double Esound = 0.;
+  if (G4CMP::IsElectron(trk)) {
+    Esound = theLattice->MapV_elToEkin(GetValleyIndex(trk), v_el);
+  } else {
+    Esound = trk->GetKineticEnergy();
+  }
 
   if (verboseLevel>1) {
     G4cout << "G4CMPLukeEmissionRate::Threshold vtrk " << vtrk.mag()/(m/s)

--- a/library/src/G4CMPLukeEmissionRate.cc
+++ b/library/src/G4CMPLukeEmissionRate.cc
@@ -11,6 +11,7 @@
 // 20170815  Drop call to LoadDataForTrack(); now handled in process.
 // 20170913  Check for electric field; compute "rate" to get up to Vsound
 // 20170917  Add interface for threshold identification
+// 20240207  Replacing wave vector with speed to Emission calculations
 
 #include "G4CMPLukeEmissionRate.hh"
 #include "G4CMPGeometryUtils.hh"

--- a/library/src/G4CMPLukeScattering.cc
+++ b/library/src/G4CMPLukeScattering.cc
@@ -81,7 +81,7 @@ G4CMPLukeScattering::~G4CMPLukeScattering() {
 
 G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
                                                      const G4Step& aStep) {
-  aParticleChange.Initialize(aTrack); 
+  InitializeParticleChange(GetValleyIndex(aTrack), aTrack);
   G4StepPoint* postStepPoint = aStep.GetPostStepPoint();
   
   if (verboseLevel > 1) {
@@ -140,8 +140,8 @@ G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
 
   G4ThreeVector kdir = ktrk.unit();
   G4double kmag = ktrk.mag();
-  G4double gammaSound = 1/sqrt(1.-lat->GetSoundSpeed()*lat->GetSoundSpeed()/c_squared);
-  G4double kSound = gammaSound * lat->GetSoundSpeed() * mass / hbar_Planck;
+  G4ThreeVector vSound = lat->GetSoundSpeed()*kdir;
+  G4double kSound = (lat->MapV_elToK_HV(iValley,vSound)).mag();
 
   // Sanity check: this should have been done in MFP already
   if (kmag <= kSound) return &aParticleChange;

--- a/library/src/G4CMPLukeScattering.cc
+++ b/library/src/G4CMPLukeScattering.cc
@@ -140,8 +140,15 @@ G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
 
   G4ThreeVector kdir = ktrk.unit();
   G4double kmag = ktrk.mag();
-  G4ThreeVector vSound = lat->GetSoundSpeed()*kdir;
-  G4double kSound = (lat->MapV_elToK_HV(iValley,vSound)).mag();
+  G4double kSound = 0.;
+  if (IsElectron()) {
+    G4ThreeVector vSound = lat->GetSoundSpeed()*kdir;
+    kSound = (lat->MapV_elToK_HV(iValley,vSound)).mag();
+  }
+  else{
+    G4double gammaSound = 1/sqrt(1.-lat->GetSoundSpeed()*lat->GetSoundSpeed()/c_squared);
+    kSound = gammaSound * lat->GetSoundSpeed() * mass / hbar_Planck;
+  }
 
   // Sanity check: this should have been done in MFP already
   if (kmag <= kSound) return &aParticleChange;

--- a/library/src/G4CMPLukeScattering.cc
+++ b/library/src/G4CMPLukeScattering.cc
@@ -120,13 +120,13 @@ G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
   G4int iValley = GetValleyIndex(aTrack);	// Doesn't change valley
 
   // NOTE: Track kinematics include post-step acceleration from E-field
-  G4ThreeVector ptrk = GetLocalMomentum(aTrack);
+  G4ThreeVector ptrk = GetLocalDirection(aStep.GetPostStepPoint()->GetMomentum());
   G4ThreeVector ktrk(0.);
   G4double mass = 0.;
   G4double Etrk = 0.;
   if (IsElectron()) {
     ktrk = lat->MapPtoK_HV(iValley, ptrk);
-    mass = lat->GetElectronEffectiveMass(iValley, ptrk);
+    mass = electron_mass_c2/c_squared;
     Etrk = lat->MapPtoEkin(iValley, ptrk);
   } else if (IsHole()) {
     ktrk = GetLocalWaveVector(aTrack);
@@ -140,7 +140,8 @@ G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
 
   G4ThreeVector kdir = ktrk.unit();
   G4double kmag = ktrk.mag();
-  G4double kSound = lat->GetSoundSpeed() * mass / hbar_Planck;
+  G4double gammaSound = 1/sqrt(1.-lat->GetSoundSpeed()*lat->GetSoundSpeed()/c_squared);
+  G4double kSound = gammaSound * lat->GetSoundSpeed() * mass / hbar_Planck;
 
   // Sanity check: this should have been done in MFP already
   if (kmag <= kSound) return &aParticleChange;

--- a/library/src/G4CMPLukeScattering.cc
+++ b/library/src/G4CMPLukeScattering.cc
@@ -35,6 +35,9 @@
 // 		significance.
 // 20221210  Fix to where Erecoil mass was not being multiplied by c_squared
 // 		for Holes, resulting into wrong units.
+// 20240207  Adapting Luke Scattering with new kinematics. Reverting the
+//              use of effective mass for electrons and adding electron mass
+//              back. Adding InitializeParticleChange to get the correct Ekin
 
 #include "G4CMPLukeScattering.hh"
 #include "G4CMPConfigManager.hh"

--- a/library/src/G4CMPTimeStepper.cc
+++ b/library/src/G4CMPTimeStepper.cc
@@ -42,6 +42,8 @@
 // 20230702  I. Ataee -- Add energy recalculations in PostStepDoIt to correct
 //		the energy change after each step under voltage and account for band 
 //		structure effects.
+// 20240207  I. Ataee -- Adding a dynamic mfp minimum calculation to account for
+//              current charge momentum to have smaller steps at direction flips
 
 #include "G4CMPTimeStepper.hh"
 #include "G4CMPConfigManager.hh"

--- a/library/src/G4CMPTimeStepper.cc
+++ b/library/src/G4CMPTimeStepper.cc
@@ -121,6 +121,8 @@ G4double G4CMPTimeStepper::GetMeanFreePath(const G4Track& aTrack, G4double,
 
   *cond = NotForced;
 
+  if (aTrack.GetCurrentStepNumber() == 1) return 1e-12*m;
+
   // SPECIAL:  If no electric field, no need to limit steps
   if (G4CMP::GetFieldAtPosition(aTrack).mag() <= 0.) return DBL_MAX;
 
@@ -150,7 +152,9 @@ G4double G4CMPTimeStepper::GetMeanFreePath(const G4Track& aTrack, G4double,
 
   // Take shortest distance from above options
   // G4double mfp = std::min({mfpFast, mfpLuke, mfpIV});
-  G4double mfp = std::min({1e-6*m, mfpFast, mfpLuke, mfpIV});
+  G4double trackP = aTrack.GetMomentum().mag()/eV;
+  G4double genericmfp = std::max(1e-10*m * (trackP*trackP), 1e-10*m);
+  G4double mfp = std::min({genericmfp, 1e-6*m, mfpFast, mfpLuke, mfpIV});
 
   if (verboseLevel) {
     G4cout << GetProcessName() << (IsElectron()?" elec":" hole")

--- a/library/src/G4CMPTimeStepper.cc
+++ b/library/src/G4CMPTimeStepper.cc
@@ -149,7 +149,8 @@ G4double G4CMPTimeStepper::GetMeanFreePath(const G4Track& aTrack, G4double,
     G4cout << "TS IV threshold mfpIV " << mfpIV/m << " m" << G4endl;
 
   // Take shortest distance from above options
-  G4double mfp = std::min({mfpFast, mfpLuke, mfpIV});
+  // G4double mfp = std::min({mfpFast, mfpLuke, mfpIV});
+  G4double mfp = std::min({1e-6*m, mfpFast, mfpLuke, mfpIV});
 
   if (verboseLevel) {
     G4cout << GetProcessName() << (IsElectron()?" elec":" hole")
@@ -164,26 +165,12 @@ G4double G4CMPTimeStepper::GetMeanFreePath(const G4Track& aTrack, G4double,
 
 G4VParticleChange* G4CMPTimeStepper::PostStepDoIt(const G4Track& aTrack,
 						  const G4Step& aStep) {
-  aParticleChange.Initialize(aTrack);
-
-  // Adjust dynamical mass for electrons using end-of-step momentum direction
-  G4ThreeVector p = GetLocalDirection(aStep.GetPostStepPoint()->GetMomentum());
-
-  G4double ekin = theLattice->MapPtoEkin(GetValleyIndex(aTrack), p);
-
-  G4double meff = IsHole() ? theLattice->GetHoleMass()
-    : theLattice->GetElectronEffectiveMass(GetValleyIndex(aTrack), p);
-
-  if (IsElectron()) {
-    aParticleChange.ProposeEnergy(ekin);
-    aParticleChange.ProposeMass(meff*c_squared);
-  };
+  InitializeParticleChange(GetValleyIndex(aTrack), aTrack);
 
   // Report basic kinematics
   if (verboseLevel) {
     G4cout << GetProcessName() << (IsElectron()?" elec":" hole")
-	   << " Ekin " << GetKineticEnergy(aTrack)/eV << " eV,"
-	   << " m " << meff*c_squared/electron_mass_c2 << " m_e," << G4endl
+	   << " Ekin " << GetKineticEnergy(aTrack)/eV << " eV," << G4endl
 	   << " p " << GetGlobalMomentum(aTrack)/eV << " "
 	   << GetGlobalMomentum(aTrack).mag()/eV << " eV"
 	   << G4endl;

--- a/library/src/G4CMPVDriftProcess.cc
+++ b/library/src/G4CMPVDriftProcess.cc
@@ -110,10 +110,19 @@ void G4CMPVDriftProcess::FillParticleChange(G4int ivalley, G4double Ekin,
   G4CMP::GetTrackInfo<G4CMPDriftTrackInfo>(GetCurrentTrack())->SetValleyIndex(ivalley);
 
   aParticleChange.ProposeMomentumDirection(v.unit());
-  aParticleChange.ProposeEnergy(Ekin);
+  currentEkin = Ekin;
+  aParticleChange.ProposeEnergy(currentEkin);
 
   if (IsElectron()) {		// Geant4 wants mc^2, not plain mass
     G4double meff = theLattice->GetElectronEffectiveMass(ivalley,GetLocalDirection(v));
     aParticleChange.ProposeMass(meff*c_squared);
   }
+}
+
+// Initializing ParticleChange and setting up the correct energy and
+// effective for the charge carrier
+
+void G4CMPVDriftProcess::InitializeParticleChange(G4int ivalley, const G4Track& track) {
+  aParticleChange.Initialize(track);
+  FillParticleChange(ivalley, track.GetMomentum());
 }

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -721,9 +721,10 @@ void G4LatticeLogical::SetMassTensor(const G4RotationMatrix& etens) {
 }
 
 // Compute derived quantities from user-input mass tensor
+// apachepersonal.miun.se/~gorthu/halvledare/Effective%20mass%20in%20semiconductors.htm
 
 void G4LatticeLogical::FillMassInfo() {
-  // Herring-Vogt scalar mass of electron, used for sound speed calcs  
+  // Effective mass for conductivity calculations
   fElectronMass = 3. / ( 1./fMassTensor.xx() + 1./fMassTensor.yy()
 			 + 1./fMassTensor.zz() );  
 

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -438,7 +438,6 @@ G4LatticeLogical::MapPtoV_el(G4int ivalley, const G4ThreeVector& p_e) const {
 #endif
   const G4RotationMatrix& vToN = GetValley(ivalley);
   const G4RotationMatrix& nToV = GetValleyInv(ivalley);
-  G4cout << "Classical Velocity: " << nToV*(GetMInvTensor()*(vToN*p_e/c_light)) << " - Relativistic Velocity: " << p_e*c_light/(MapPtoEkin(ivalley,p_e) + electron_mass_c2) << G4endl;
 
   return p_e*c_light/(MapPtoEkin(ivalley,p_e) + electron_mass_c2);
 }
@@ -457,7 +456,6 @@ G4LatticeLogical::MapV_elToP(G4int ivalley, const G4ThreeVector& v_e) const {
   fMassTensor.yy()*tempvec().y()*tempvec().y() +
   fMassTensor.zz()*tempvec().z()*tempvec().z());
   G4double gamma = 1/sqrt(1-bandV/electron_mass_c2);
-  G4cout << "gamma = " << gamma << " - velocity = " << v_e << " - speed of light = " << c_light << G4endl;
   return gamma*electron_mass_c2*v_e/c_light;
 }
 


### PR DESCRIPTION
This branch is adapting the Luke Scattering Emission with new kinematics implemented in G4CMP-352 and merged into G4CMP-276.
In addition to Luke Scattering, it has a modification to Luke Scattering Rate to use velocity over wave-vector, decreasing the unnecessary complexity.
It also introduces the InitializeParticleChange utility function, which is what was previously done in TimeStepper PostStepDoIt in G4CMP-352 changes, as a way to fix the charge kinetic energy and effective mass to match new kinematics, but as it has to be done after every process (not only TimeStepper), I introduced a helper function to avoid repetition
At last, it has a minor modification to mfp calculations in TimeStepper to address the long steps in momentum direction flips.