### PR TITLE
G4CMP 395

### DIFF
--- a/library/include/G4CMPVDriftProcess.hh
+++ b/library/include/G4CMPVDriftProcess.hh
@@ -40,7 +40,7 @@ public:
 
 protected:
   // Fill ParticleChange energy and mass for charge carrier of given momentum
-  void FillParticleChange(G4int ivalley, const G4ThreeVector& p);
+  void FillParticleChange(const G4ThreeVector& p);
 
   // Fill ParticleChange energy and mass for charge carrier of given energy
   void FillParticleChange(G4int ivalley, G4double Ekin,
@@ -48,7 +48,7 @@ protected:
 
   // Initializing ParticleChange and setting up the correct energy and
   // effective for the charge carrier
-  void InitializeParticleChange(G4int ivalley, const G4Track& track);
+  void InitializeParticleChange(const G4Track& track);
 
   G4double currentEkin;	// Caching the current track kinetic energy
 

--- a/library/src/G4CMPDriftBoundaryProcess.cc
+++ b/library/src/G4CMPDriftBoundaryProcess.cc
@@ -220,7 +220,7 @@ DoReflectionElectron(const G4Track& aTrack, const G4Step& aStep,
     G4cout << " Cross-check new v dir  " << vnew.unit() << G4endl;
   }
   
-  FillParticleChange(GetCurrentValley(), p);	// Handle effective mass, vel
+  FillParticleChange(p);	// Handle effective mass, vel
 }
 
 void G4CMPDriftBoundaryProcess::

--- a/library/src/G4CMPInterValleyScattering.cc
+++ b/library/src/G4CMPInterValleyScattering.cc
@@ -136,7 +136,7 @@ G4CMPInterValleyScattering::PostStepDoIt(const G4Track& aTrack,
   if (G4UniformRand()>0.5) p = -p;
 
   // Adjust track kinematics for new valley
-  FillParticleChange(valley, p);
+  FillParticleChange(p);
   
   ClearNumberOfInteractionLengthLeft();    
   return &aParticleChange;

--- a/library/src/G4CMPLukeScattering.cc
+++ b/library/src/G4CMPLukeScattering.cc
@@ -84,7 +84,7 @@ G4CMPLukeScattering::~G4CMPLukeScattering() {
 
 G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
                                                      const G4Step& aStep) {
-  InitializeParticleChange(GetValleyIndex(aTrack), aTrack);
+  InitializeParticleChange(aTrack);
   G4StepPoint* postStepPoint = aStep.GetPostStepPoint();
   
   if (verboseLevel > 1) {
@@ -361,6 +361,7 @@ G4VParticleChange* G4CMPLukeScattering::PostStepDoIt(const G4Track& aTrack,
     aParticleChange.ProposeNonIonizingEnergyDeposit(Ephonon);
   }
 
+  newValley = FindNearestValley(precoil);
   RotateToGlobalDirection(precoil);	// Update track in world coordinates
   FillParticleChange(newValley, Erecoil, precoil);
 

--- a/library/src/G4CMPTimeStepper.cc
+++ b/library/src/G4CMPTimeStepper.cc
@@ -171,7 +171,7 @@ G4double G4CMPTimeStepper::GetMeanFreePath(const G4Track& aTrack, G4double,
 
 G4VParticleChange* G4CMPTimeStepper::PostStepDoIt(const G4Track& aTrack,
 						  const G4Step& aStep) {
-  InitializeParticleChange(GetValleyIndex(aTrack), aTrack);
+  InitializeParticleChange(aTrack);
 
   // Report basic kinematics
   if (verboseLevel) {

--- a/library/src/G4CMPVDriftProcess.cc
+++ b/library/src/G4CMPVDriftProcess.cc
@@ -90,17 +90,18 @@ G4CMPVDriftProcess::PostStepGetPhysicalInteractionLength(
 // Fill ParticleChange energy and mass for electron charge carrier momentum
 
 void 
-G4CMPVDriftProcess::FillParticleChange(G4int ivalley, const G4ThreeVector& p) {
+G4CMPVDriftProcess::FillParticleChange(const G4ThreeVector& p) {
   // Compute kinetic energy from momentum for electrons or holes
   G4double energy = 0.;
+  G4int valley = FindNearestValley(GetLocalDirection(p));
   if (IsElectron()){
-    energy = theLattice->MapPtoEkin(ivalley, GetLocalDirection(p));
+    energy = theLattice->MapPtoEkin(valley, GetLocalDirection(p));
   } else {
     // Geant4 returns the mass in energy units, with the c_squared already included
     G4double massc2 = GetCurrentTrack()->GetDynamicParticle()->GetMass();
     energy = sqrt(p.mag2() + massc2*massc2) - massc2;
   }
-  FillParticleChange(ivalley, energy, p);
+  FillParticleChange(valley, energy, p);
 }
 
 // Fill ParticleChange mass for electron charge carrier with given energy
@@ -122,7 +123,7 @@ void G4CMPVDriftProcess::FillParticleChange(G4int ivalley, G4double Ekin,
 // Initializing ParticleChange and setting up the correct energy and
 // effective for the charge carrier
 
-void G4CMPVDriftProcess::InitializeParticleChange(G4int ivalley, const G4Track& track) {
+void G4CMPVDriftProcess::InitializeParticleChange(const G4Track& track) {
   aParticleChange.Initialize(track);
-  FillParticleChange(ivalley, track.GetMomentum());
+  FillParticleChange(track.GetMomentum());
 }


### PR DESCRIPTION
In the energy-momentum calculation, we use a Taylor expansion, and the valley direction is where the energy hits its minima
The further the direction of the momentum from the valley, the bigger the inaccuracy will be
Currently, after the charge changes its direction due to scattering or transportation, the valley is not being changed.
To address this issue, a dynamic valley assignment is needed to ensure the valley the charge is assigned to is the closest valley


To do this, I propose FillParticleChange does not accept a valley input anymore; it calculates the valley from momentum and passes it to the 3-argument version of itself
The only place we use the 3-argument version of FillParticleChange is in LukeScattering, where I made it so that the valley gets calculated from Momentum