### PR TITLE
Merge G4CMP-447 to G4CMP-317

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,9 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2025-01-24  G4CMP-447 : Add utility method to update a phonon's trackInfo and
+						particleChange with wavevector and Vg.
+
 2024-10-29  g4cmp-V09-03-00 New phonon materials: Al2O3, CaF2, CaWO4, GaAs, LiF
 2024-10-24  G4CMP-387 : Incorporating five new materials into the CrystalMaps
                         folder for phonon propagation, along with an example

--- a/library/include/G4CMPProcessUtils.hh
+++ b/library/include/G4CMPProcessUtils.hh
@@ -40,6 +40,8 @@
 // 20211001  FindNearestValley(dir) can pass by reference.
 // 20211003  Add track touchable as data member, to create if needed
 // 20240303  Add local currentTouchable pointer for non-tracking situations.
+// 20250124  Add FillParticleChange() to update trackInfo with k and 
+//    particleChange with corresponding momentum and group velocity.
 
 #ifndef G4CMPProcessUtils_hh
 #define G4CMPProcessUtils_hh 1
@@ -74,6 +76,10 @@ public:
   virtual void LoadDataForTrack(const G4Track* track);
   virtual void SetCurrentTrack(const G4Track* track);
   virtual void SetLattice(const G4Track* track);
+
+  // Update particleChange's wavevector, group velocity, and momentum
+  void FillParticleChange(G4ParticleChange& particleChange,
+              const G4Track& track, const G4ThreeVector& wavevector)
 
   virtual void ReleaseTrack();
   // NOTE:  Subclasses may overload these, but be sure to callback to base

--- a/library/include/G4CMPProcessUtils.hh
+++ b/library/include/G4CMPProcessUtils.hh
@@ -40,8 +40,7 @@
 // 20211001  FindNearestValley(dir) can pass by reference.
 // 20211003  Add track touchable as data member, to create if needed
 // 20240303  Add local currentTouchable pointer for non-tracking situations.
-// 20250124  Add FillParticleChange() to update trackInfo with k and 
-//    particleChange with corresponding momentum and group velocity.
+// 20250124  Add FillParticleChange() to update phonon wavevector and Vg.
 
 #ifndef G4CMPProcessUtils_hh
 #define G4CMPProcessUtils_hh 1

--- a/library/include/G4CMPProcessUtils.hh
+++ b/library/include/G4CMPProcessUtils.hh
@@ -59,6 +59,7 @@ class G4LatticePhysical;
 class G4ParticleDefinition;
 class G4VPhysicalVolume;
 class G4VTouchable;
+class G4ParticleChange;
 
 
 class G4CMPProcessUtils {
@@ -79,7 +80,7 @@ public:
 
   // Update particleChange's wavevector, group velocity, and momentum
   void FillParticleChange(G4ParticleChange& particleChange,
-              const G4Track& track, const G4ThreeVector& wavevector)
+              const G4Track& track, const G4ThreeVector& wavevector) const;
 
   virtual void ReleaseTrack();
   // NOTE:  Subclasses may overload these, but be sure to callback to base

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -249,9 +249,9 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
 					: "on surface") << G4endl;
   }
 
-  trackInfo->SetWaveVector(reflectedKDir);
-  particleChange.ProposeVelocity(v);
-  particleChange.ProposeMomentumDirection(vdir);
+  // Update trackInfo wavevector and particleChange's group velocity and momentum direction
+  // reflectedKDir is in global coordinates here - no conversion needed
+  FillParticleChange(particleChange, aTrack, reflectedKDir)
 }
 
 

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -29,6 +29,7 @@
 // 20220905  G4CMP-310 -- Add increments of kPerp to avoid bad reflections.
 // 20220910  G4CMP-299 -- Use fabs(k) in absorption test.
 // 20240718  G4CMP-317 -- Initial implementation of surface displacement.
+// 20250124  G4CMP-447 -- Use FillParticleChange() to update wavevector and Vg.
 
 #include "G4CMPPhononBoundaryProcess.hh"
 #include "G4CMPAnharmonicDecay.hh"

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -216,7 +216,6 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
   }
 
   G4ThreeVector vdir = theLattice->MapKtoVDir(mode, reflectedKDir);
-  G4double v = theLattice->MapKtoV(mode, reflectedKDir);
 
   if (verboseLevel>2) {
     G4cout << "\n New wavevector direction " << reflectedKDir
@@ -251,7 +250,7 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
 
   // Update trackInfo wavevector and particleChange's group velocity and momentum direction
   // reflectedKDir is in global coordinates here - no conversion needed
-  FillParticleChange(particleChange, aTrack, reflectedKDir)
+  FillParticleChange(particleChange, aTrack, reflectedKDir);
 }
 
 

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -216,7 +216,11 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
     refltype = "diffuse";
   }
 
-  G4ThreeVector vdir = theLattice->MapKtoVDir(mode, reflectedKDir);
+  // Update trackInfo wavevector and particleChange's group velocity and momentum direction
+  // reflectedKDir is in global coordinates here - no conversion needed
+  FillParticleChange(particleChange, aTrack, reflectedKDir);
+
+  G4ThreeVector vdir = *particleChange.GetMomentumDirection();
 
   if (verboseLevel>2) {
     G4cout << "\n New wavevector direction " << reflectedKDir
@@ -248,10 +252,6 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
 					: place==kOutside ? "OUTSIDE"
 					: "on surface") << G4endl;
   }
-
-  // Update trackInfo wavevector and particleChange's group velocity and momentum direction
-  // reflectedKDir is in global coordinates here - no conversion needed
-  FillParticleChange(particleChange, aTrack, reflectedKDir);
 }
 
 

--- a/library/src/G4CMPPhononElectrode.cc
+++ b/library/src/G4CMPPhononElectrode.cc
@@ -35,6 +35,7 @@
 // 
 // 20221006  M. Kelsey -- Adapted from SuperCDMS simulation version
 // 20221006  G4CMP-330 -- Add lattice temperature to properties table
+// 20250124  G4CMP-447 -- Add FillParticleChange() to update phonon track info
 
 #include "G4CMPPhononElectrode.hh"
 #include "G4CMPGeometryUtils.hh"
@@ -191,7 +192,7 @@ ProcessReflection(const G4Track& track, const G4Step& step,
   if (verboseLevel>1)
     G4cout << " Phonon reflected from QET toward " << reflectedKDir << G4endl;
 
-  particleChange.ProposeMomentumDirection(reflectedKDir);
+  FillParticleChange(particleChange, track, reflectedKDir)
 
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->IncrementReflectionCount();

--- a/library/src/G4CMPPhononElectrode.cc
+++ b/library/src/G4CMPPhononElectrode.cc
@@ -189,10 +189,13 @@ ProcessReflection(const G4Track& track, const G4Step& step,
   } while (!G4CMP::PhononVelocityIsInward(theLattice, pol,
 					  reflectedKDir, surfNorm));
 
-  if (verboseLevel>1)
-    G4cout << " Phonon reflected from QET toward " << reflectedKDir << G4endl;
+  FillParticleChange(particleChange, track, reflectedKDir);
 
-  FillParticleChange(particleChange, track, reflectedKDir)
+  if (verboseLevel>1){
+    G4cout << " Phonon reflected from QET with: Wavevector " << reflectedKDir
+    << ", Momentum " << *particleChange.GetMomentumDirection()
+    << ", Velocity " << particleChange.GetVelocity() << G4endl;
+  }
 
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->IncrementReflectionCount();

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -54,6 +54,7 @@
 // 20240402  Drop FindTouchable() function.  Set currentTouchable internally
 //		not available from track, and delete it at end of track.
 // 20250124  Add FillParticleChange() to update phonon wavevector and Vg.
+// 20250129  Rotate Vg in FillParticleChange() to global coordinates.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -208,7 +209,7 @@ void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->SetWaveVector(wavevector);
   particleChange.ProposeVelocity(v);
-  vDir = RotateToGlobalDirection(vDir);
+  RotateToGlobalDirection(vDir);
   particleChange.ProposeMomentumDirection(vDir);
 }
 

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -53,8 +53,7 @@
 // 20240303  Add local currentTouchable pointer for non-tracking situations.
 // 20240402  Drop FindTouchable() function.  Set currentTouchable internally
 //		not available from track, and delete it at end of track.
-// 20250124  Add FillParticleChange() to update trackInfo with k and 
-//    particleChange with corresponding momentum and group velocity.
+// 20250124  Add FillParticleChange() to update phonon wavevector and Vg.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -193,6 +192,7 @@ void G4CMPProcessUtils::FindLattice(const G4VPhysicalVolume* volume) {
   }
 }
 
+
 // Fill ParticleChange wavevector and group velocity for a given wavevector
 // Wavevector is expected to be in the global coordinate frame
 void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
@@ -210,6 +210,7 @@ void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
   particleChange.ProposeVelocity(v);
   particleChange.ProposeMomentumDirection(vDir);
 }
+
 
 // Delete current configuration before new track starts
 

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -202,8 +202,8 @@ void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
   G4int mode = GetPolarization(track);
 
   // Get Vg from global wavevector
-  G4ThreeVector vDir = theLattice->MapKtoVDir(mode, wavevector);
-  G4double v = theLattice->MapKtoV(mode, wavevector);
+  G4ThreeVector vDir = theLattice->MapKtoVDir(mode, GetLocalDirection(wavevector));
+  G4double v = theLattice->MapKtoV(mode, GetLocalDirection(wavevector));
 
   // Update trackInfo and particleChange
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -196,27 +196,19 @@ void G4CMPProcessUtils::FindLattice(const G4VPhysicalVolume* volume) {
 // Fill ParticleChange wavevector and group velocity for a given wavevector
 // Wavevector is expected to be in the global coordinate frame
 void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
-            const G4Track& track, const G4ThreeVector& wavevector) {
+            const G4Track& track, const G4ThreeVector& wavevector) const {
   // Get phonon mode from track
   G4int mode = GetPolarization(track);
 
   // Get Vg from global wavevector
-  G4ThreeVector vDir = theLattice->MapKtoVDir(mode, wavevector)
+  G4ThreeVector vDir = theLattice->MapKtoVDir(mode, wavevector);
   G4double v = theLattice->MapKtoV(mode, wavevector);
 
   // Update trackInfo and particleChange
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->SetWaveVector(wavevector);
   particleChange.ProposeVelocity(v);
-  particleChange.ProposeMomentumDirection(vdir);
-}
-
-void G4CMPProcessUtils::GetGlobalPosition(const G4Track& track,
-           G4double pos[3]) const {
-  tempvec = GetGlobalPosition(track);
-  pos[0] = tempvec.x();
-  pos[1] = tempvec.y();
-  pos[2] = tempvec.z();
+  particleChange.ProposeMomentumDirection(vDir);
 }
 
 // Delete current configuration before new track starts

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -208,6 +208,7 @@ void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
   auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
   trackInfo->SetWaveVector(wavevector);
   particleChange.ProposeVelocity(v);
+  vDir = RotateToGlobalDirection(vDir);
   particleChange.ProposeMomentumDirection(vDir);
 }
 

--- a/library/src/G4CMPProcessUtils.cc
+++ b/library/src/G4CMPProcessUtils.cc
@@ -53,6 +53,8 @@
 // 20240303  Add local currentTouchable pointer for non-tracking situations.
 // 20240402  Drop FindTouchable() function.  Set currentTouchable internally
 //		not available from track, and delete it at end of track.
+// 20250124  Add FillParticleChange() to update trackInfo with k and 
+//    particleChange with corresponding momentum and group velocity.
 
 #include "G4CMPProcessUtils.hh"
 #include "G4CMPDriftElectron.hh"
@@ -191,6 +193,31 @@ void G4CMPProcessUtils::FindLattice(const G4VPhysicalVolume* volume) {
   }
 }
 
+// Fill ParticleChange wavevector and group velocity for a given wavevector
+// Wavevector is expected to be in the global coordinate frame
+void G4CMPProcessUtils::FillParticleChange(G4ParticleChange& particleChange,
+            const G4Track& track, const G4ThreeVector& wavevector) {
+  // Get phonon mode from track
+  G4int mode = GetPolarization(track);
+
+  // Get Vg from global wavevector
+  G4ThreeVector vDir = theLattice->MapKtoVDir(mode, wavevector)
+  G4double v = theLattice->MapKtoV(mode, wavevector);
+
+  // Update trackInfo and particleChange
+  auto trackInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(track);
+  trackInfo->SetWaveVector(wavevector);
+  particleChange.ProposeVelocity(v);
+  particleChange.ProposeMomentumDirection(vdir);
+}
+
+void G4CMPProcessUtils::GetGlobalPosition(const G4Track& track,
+           G4double pos[3]) const {
+  tempvec = GetGlobalPosition(track);
+  pos[0] = tempvec.x();
+  pos[1] = tempvec.y();
+  pos[2] = tempvec.z();
+}
 
 // Delete current configuration before new track starts
 

--- a/library/src/G4PhononScattering.cc
+++ b/library/src/G4PhononScattering.cc
@@ -91,10 +91,10 @@ G4VParticleChange* G4PhononScattering::PostStepDoIt( const G4Track& aTrack,
   }
 
   // Update particleChange with new wavevector and Vg
-  FillParticleChange(aParticleChange, aTrack, newK)
+  FillParticleChange(aParticleChange, aTrack, newK);
 
   if (verboseLevel>1)
-    G4cout << " new vgrp " << particleChange.GetVelocity() << " along " << *particleChange.GetMomentumDirection() << G4endl;
+    G4cout << " new vgrp " << aParticleChange.GetVelocity() << " along " << *aParticleChange.GetMomentumDirection() << G4endl;
 
   ClearNumberOfInteractionLengthLeft();		// All processes should do this!
   return &aParticleChange;

--- a/library/src/G4PhononScattering.cc
+++ b/library/src/G4PhononScattering.cc
@@ -14,6 +14,7 @@
 // 20170620  Follow interface changes in G4CMPSecondaryUtils
 // 20170805  Move GetMeanFreePath() to scattering-rate model
 // 20170819  Overwrite track's particle definition instead of killing
+// 20250129  Call FillParticleChange() to update phonon track information.
 
 #include "G4PhononScattering.hh"
 #include "G4CMPPhononScatteringRate.hh"
@@ -89,20 +90,11 @@ G4VParticleChange* G4PhononScattering::PostStepDoIt( const G4Track& aTrack,
     }
   }
 
-  // Assign new wave vector direction to track (ought to happen later!)
-  auto trkInfo = G4CMP::GetTrackInfo<G4CMPPhononTrackInfo>(aTrack);
-  trkInfo->SetWaveVector(newK);
-
-  // Set velocity and direction according to new wave vector direction
-  G4double vgrp = theLattice->MapKtoV(mode, newK);
-  G4ThreeVector vdir = theLattice->MapKtoVDir(mode, newK);
-  RotateToGlobalDirection(vdir);
+  // Update particleChange with new wavevector and Vg
+  FillParticleChange(aParticleChange, aTrack, newK)
 
   if (verboseLevel>1)
-    G4cout << " new vgrp " << vgrp << " along " << vdir << G4endl;
-
-  aParticleChange.ProposeMomentumDirection(vdir);
-  aParticleChange.ProposeVelocity(vgrp);
+    G4cout << " new vgrp " << particleChange.GetVelocity() << " along " << *particleChange.GetMomentumDirection() << G4endl;
 
   ClearNumberOfInteractionLengthLeft();		// All processes should do this!
   return &aParticleChange;


### PR DESCRIPTION
This adds the FillParticleChange() method that updates the phonon's wavevector, momentum direction, and velocity double after a reflection and after QET emission. 