### PR TITLE
Merge G4CMP-453  to G4CMP-317

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -11,6 +11,8 @@ ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 2025-01-24  G4CMP-447 : Add utility method to update a phonon's trackInfo and
                         particleChange with wavevector and Vg.
 2025-01-30  G4CMP-453 : Apply coordinate rotations in PhononVelocityIsInward.
+						Add utility functions to G4CMPUtils to get current
+						track and touchable from G4EventManager.
 *** DO NOT ADD ANY TAG MESSAGES BELOW THIS LINE ***
 
 2024-10-29  g4cmp-V09-03-00 New phonon materials: Al2O3, CaF2, CaWO4, GaAs, LiF

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,12 +7,10 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 *** ADD NEW TAG MESSAGES BELOW G4CMP-317 LINE, UPDATE DATE OF G4CMP-317 ***
-2025-01-29  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-01-30  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-01-30  G4CMP-453 : Add rotations and utilities for PhononVelocityIsInward.
 2025-01-24  G4CMP-447 : Add utility method to update a phonon's trackInfo and
                         particleChange with wavevector and Vg.
-2025-01-30  G4CMP-453 : Apply coordinate rotations in PhononVelocityIsInward.
-						Add utility functions to G4CMPUtils to get current
-						track and touchable from G4EventManager.
 *** DO NOT ADD ANY TAG MESSAGES BELOW THIS LINE ***
 
 2024-10-29  g4cmp-V09-03-00 New phonon materials: Al2O3, CaF2, CaWO4, GaAs, LiF

--- a/ChangeHistory
+++ b/ChangeHistory
@@ -10,6 +10,7 @@ ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 2025-01-29  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
 2025-01-24  G4CMP-447 : Add utility method to update a phonon's trackInfo and
                         particleChange with wavevector and Vg.
+2025-01-30  G4CMP-453 : Apply coordinate rotations in PhononVelocityIsInward.
 *** DO NOT ADD ANY TAG MESSAGES BELOW THIS LINE ***
 
 2024-10-29  g4cmp-V09-03-00 New phonon materials: Al2O3, CaF2, CaWO4, GaAs, LiF

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -16,6 +16,7 @@
 // 20190906  Add function to get process associated with particle
 // 20220816  Move RandomIndex function from SecondaryProduction
 // 20220921  G4CMP-319 -- Add utilities for thermal (Maxwellian) distributions
+// 20250130  G4CMP-453 -- Add utilities for getting current track and touchable
 
 #ifndef G4CMPUtils_hh
 #define G4CMPUtils_hh 1
@@ -70,6 +71,13 @@ namespace G4CMP {
   G4double ChoosePhononWeight(G4double biasScale=-1.);
   G4double ChooseChargeWeight(G4double biasScale=-1.);
 
+  // Get the current track from G4EventManager
+  G4Track* G4CMP::GetCurrentTrack();
+
+  // Get current touchable from track
+  const G4VTouchable* G4CMP::GetCurrentTouchable();
+  const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track);
+
   // Create a Hit from a G4Step. Less error prone to use this helper.
   void FillHit(const G4Step*, G4CMPElectrodeHit*);
 
@@ -77,6 +85,7 @@ namespace G4CMP {
   G4ThreeVector LambertReflection(const G4ThreeVector& surfNorm);
 
   // Test that a phonon's wave vector relates to an inward velocity.
+  // waveVector and surfNorm need to be in global coordinates
   G4bool PhononVelocityIsInward(const G4LatticePhysical* lattice, G4int mode,
                                 const G4ThreeVector& waveVector,
                                 const G4ThreeVector& surfNorm);

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -72,11 +72,11 @@ namespace G4CMP {
   G4double ChooseChargeWeight(G4double biasScale=-1.);
 
   // Get the current track from G4EventManager
-  G4Track* G4CMP::GetCurrentTrack();
+  G4Track* GetCurrentTrack();
 
   // Get current touchable from track
-  const G4VTouchable* G4CMP::GetCurrentTouchable();
-  const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track);
+  const G4VTouchable* GetCurrentTouchable();
+  const G4VTouchable* GetCurrentTouchable(G4Track* track);
 
   // Create a Hit from a G4Step. Less error prone to use this helper.
   void FillHit(const G4Step*, G4CMPElectrodeHit*);

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -77,7 +77,6 @@ namespace G4CMP {
 
   // Get current touchable from track
   const G4VTouchable* GetCurrentTouchable();
-  const G4VTouchable* GetCurrentTouchable(G4Track* track);
 
   // Create a Hit from a G4Step. Less error prone to use this helper.
   void FillHit(const G4Step*, G4CMPElectrodeHit*);

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -30,6 +30,7 @@ class G4ParticleDefinition;
 class G4Step;
 class G4Track;
 class G4VProcess;
+class G4VTouchable;
 
 
 namespace G4CMP {

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -23,6 +23,7 @@
 #include "G4CMPDriftElectron.hh"
 #include "G4CMPDriftHole.hh"
 #include "G4CMPElectrodeHit.hh"
+#include "G4CMPGeometryUtils.hh"
 #include "G4CMPTrackUtils.hh"
 #include "G4LatticePhysical.hh"
 #include "G4ParticleDefinition.hh"
@@ -206,10 +207,10 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      const G4ThreeVector& waveVector,
                                      const G4ThreeVector& surfNorm) {
   // MapKtoVDir requires local direction for the wavevector
-  G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(waveVector));
+  G4ThreeVector vDir = lattice->MapKtoVDir(mode, G4CMP::GetLocalDirection(waveVector));
 
   // Compare group velocity and surface normal in global coordinates
-  RotateToGlobalDirection(vDir);
+  G4CMP::RotateToGlobalDirection(vDir);
   return vDir.dot(surfNorm) < 0.0;
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -16,6 +16,7 @@
 // 20190906  M. Kelsey -- Add function to look up process for track
 // 20220816  M. Kelsey -- Move RandomIndex here for more general use
 // 20220921  G4CMP-319 -- Add utilities for thermal (Maxwellian) distributions
+// 20250130  G4CMP-453 -- Apply coordinate rotations in PhononVelocityIsInward
 
 #include "G4CMPUtils.hh"
 #include "G4CMPConfigManager.hh"
@@ -199,12 +200,16 @@ G4ThreeVector G4CMP::LambertReflection(const G4ThreeVector& surfNorm) {
 
 
 // Check that phonon is properly directed from the volume surface
-
+// waveVector and surfNorm need to be in global coordinates
 G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      G4int mode,
                                      const G4ThreeVector& waveVector,
                                      const G4ThreeVector& surfNorm) {
-  G4ThreeVector vDir = lattice->MapKtoVDir(mode, waveVector);
+  // MapKtoVDir requires local direction for the wavevector
+  G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(waveVector));
+
+  // Compare group velocity and surface normal in global coordinates
+  RotateToGlobalDirection(vDir);
   return vDir.dot(surfNorm) < 0.0;
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -210,13 +210,13 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      const G4ThreeVector& surfNorm) {
   // Get track and touchable for coordinate rotations
   G4Track* track = G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
-  G4VTouchable* touchable = track->GetStep()->GetPostStepPoint()->GetTouchable();
+  const G4VTouchable* touchable = track->GetStep()->GetPostStepPoint()->GetTouchable();
 
   // MapKtoVDir requires local direction for the wavevector
-  G4ThreeVector vDir = lattice->MapKtoVDir(mode, touchable->GetLocalDirection(waveVector));
+  G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(touchable, waveVector));
 
   // Compare group velocity and surface normal in global coordinates
-  touchable->RotateToGlobalDirection(vDir);
+  RotateToGlobalDirection(touchable, vDir);
   return vDir.dot(surfNorm) < 0.0;
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -26,6 +26,7 @@
 #include "G4CMPGeometryUtils.hh"
 #include "G4CMPTrackUtils.hh"
 #include "G4EventManager.hh"
+#include "G4ExceptionSeverity.hh"
 #include "G4LatticePhysical.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4PhononPolarization.hh"
@@ -223,7 +224,10 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      const G4ThreeVector& surfNorm) {
   // Get touchable for coordinate rotations
   const G4VTouchable* touchable = GetCurrentTouchable();
-
+  if (!touchable) {
+    G4Exception(("G4CMP::PhononVelocityIsInward").c_str(), "G4CMPUtils001",
+		FatalException, ("Current track does not have valid touchable!").c_str());
+  }
   // MapKtoVDir requires local direction for the wavevector
   G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(touchable, waveVector));
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -225,8 +225,8 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
   // Get touchable for coordinate rotations
   const G4VTouchable* touchable = GetCurrentTouchable();
   if (!touchable) {
-    G4Exception(("G4CMP::PhononVelocityIsInward").c_str(), "G4CMPUtils001",
-		FatalException, ("Current track does not have valid touchable!").c_str());
+    G4Exception("G4CMP::PhononVelocityIsInward", "G4CMPUtils001",
+		FatalException, "Current track does not have valid touchable!");
   }
   // MapKtoVDir requires local direction for the wavevector
   G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(touchable, waveVector));

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -227,7 +227,8 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
 
   if (!touchable) {
     G4Exception("G4CMP::PhononVelocityIsInward", "G4CMPUtils001",
-		FatalException, "Current track does not have valid touchable!");
+		EventMustBeAborted, "Current track does not have valid touchable!");
+    return false;
   }
 
   // MapKtoVDir requires local direction for the wavevector

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -164,12 +164,12 @@ G4Track* G4CMP::GetCurrentTrack() {
 
 // Get touchable from current track
 
-const G4VTouchable* G4CMP::GetCurrentTouchable(){
+const G4VTouchable* G4CMP::GetCurrentTouchable() {
   G4Track* track = GetCurrentTrack();
   return GetCurrentTouchable(track);
 }
 
-const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track){
+const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track) {
   return track->GetTouchable();
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -207,10 +207,10 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      const G4ThreeVector& waveVector,
                                      const G4ThreeVector& surfNorm) {
   // MapKtoVDir requires local direction for the wavevector
-  G4ThreeVector vDir = lattice->MapKtoVDir(mode, G4CMP::GetLocalDirection(waveVector));
+  G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(waveVector));
 
   // Compare group velocity and surface normal in global coordinates
-  G4CMP::RotateToGlobalDirection(vDir);
+  RotateToGlobalDirection(vDir);
   return vDir.dot(surfNorm) < 0.0;
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -25,6 +25,7 @@
 #include "G4CMPElectrodeHit.hh"
 #include "G4CMPGeometryUtils.hh"
 #include "G4CMPTrackUtils.hh"
+#include "G4EventManager.hh"
 #include "G4LatticePhysical.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4PhononPolarization.hh"
@@ -32,6 +33,7 @@
 #include "G4ProcessManager.hh"
 #include "G4ProcessVector.hh"
 #include "G4Track.hh"
+#include "G4TrackingManager.hh"
 #include "G4VProcess.hh"
 #include "Randomize.hh"
 
@@ -206,11 +208,15 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      G4int mode,
                                      const G4ThreeVector& waveVector,
                                      const G4ThreeVector& surfNorm) {
+  // Get track and touchable for coordinate rotations
+  G4Track* track = G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
+  G4VTouchable* touchable = track->GetStep()->GetPostStepPoint()->GetTouchable();
+
   // MapKtoVDir requires local direction for the wavevector
-  G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(waveVector));
+  G4ThreeVector vDir = lattice->MapKtoVDir(mode, touchable->GetLocalDirection(waveVector));
 
   // Compare group velocity and surface normal in global coordinates
-  RotateToGlobalDirection(vDir);
+  touchable->RotateToGlobalDirection(vDir);
   return vDir.dot(surfNorm) < 0.0;
 }
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -224,10 +224,12 @@ G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      const G4ThreeVector& surfNorm) {
   // Get touchable for coordinate rotations
   const G4VTouchable* touchable = GetCurrentTouchable();
+
   if (!touchable) {
     G4Exception("G4CMP::PhononVelocityIsInward", "G4CMPUtils001",
 		FatalException, "Current track does not have valid touchable!");
   }
+
   // MapKtoVDir requires local direction for the wavevector
   G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(touchable, waveVector));
 

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -166,11 +166,7 @@ G4Track* G4CMP::GetCurrentTrack() {
 
 const G4VTouchable* G4CMP::GetCurrentTouchable() {
   G4Track* track = GetCurrentTrack();
-  return GetCurrentTouchable(track);
-}
-
-const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track) {
-  return track->GetTouchable();
+  return track ? track->GetTouchable() : 0;
 }
 
 // Copy information from current step into data block]

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -156,6 +156,22 @@ G4double G4CMP::ChooseChargeWeight(G4double prob) {
   return ((prob==1.) ? 1. : (G4UniformRand()<prob) ? 1./prob : 0.);
 }
 
+// Get current track from event and track managers
+
+G4Track* G4CMP::GetCurrentTrack() {
+  return G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
+}
+
+// Get touchable from current track
+
+const G4VTouchable* G4CMP::GetCurrentTouchable(){
+  G4Track* track = GetCurrentTrack();
+  return GetCurrentTouchable(track);
+}
+
+const G4VTouchable* G4CMP::GetCurrentTouchable(G4Track* track){
+  return track->GetTouchable();
+}
 
 // Copy information from current step into data block]
 
@@ -204,13 +220,13 @@ G4ThreeVector G4CMP::LambertReflection(const G4ThreeVector& surfNorm) {
 
 // Check that phonon is properly directed from the volume surface
 // waveVector and surfNorm need to be in global coordinates
+
 G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      G4int mode,
                                      const G4ThreeVector& waveVector,
                                      const G4ThreeVector& surfNorm) {
-  // Get track and touchable for coordinate rotations
-  G4Track* track = G4EventManager::GetEventManager()->GetTrackingManager()->GetTrack();
-  const G4VTouchable* touchable = track->GetStep()->GetPostStepPoint()->GetTouchable();
+  // Get touchable for coordinate rotations
+  const G4VTouchable* touchable = GetCurrentTouchable();
 
   // MapKtoVDir requires local direction for the wavevector
   G4ThreeVector vDir = lattice->MapKtoVDir(mode, GetLocalDirection(touchable, waveVector));


### PR DESCRIPTION
This branch introduces utility functions for getting the current track and current touchable pointers from the G4EventManeger. These utilities are used to do the coordinate rotations in PhononVelocityIsInward.