### PR TITLE
G4CMP 471

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,7 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 *** ADD NEW TAG MESSAGES BELOW G4CMP-317 LINE, UPDATE DATE OF G4CMP-317 ***
-2025-05-05  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-05-07  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-05-07  G4CMP-471 : Ensure that all diagnostics are hidden and have appropriate verbosity levels.
 2025-05-05  G4CMP-479 : Update phonon time to account for surface displacement.
 2025-04-30  G4CMP-461 : Add ability to skip over flats in specular reflections.
 2025-04-28  G4CMP-465 : Implement G4CMPSolidUtils for custom solid functions.

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -430,8 +430,7 @@ GetSpecularVector(const G4ThreeVector& waveVector,
   if (!G4CMP::PhononVelocityIsInward(theLattice, mode, reflectedKDir, newNorm,
                                      GetGlobalPosition(stepLocalPos))) {
     if (verboseLevel) {
-      G4cout << (GetProcessName()+"::GetSpecularVector").c_str()
-        << ": Phonon displacement failed after " << nAttempts - 1 << " attempts. " << G4endl
+      G4cout << (GetProcessName()+"::GetSpecularVector").c_str()<< G4endl
     }
 
     // reflectedKDir and stepLocalPos will be in global coordinates

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -257,8 +257,8 @@ DoReflection(const G4Track& aTrack, const G4Step& aStep,
   }
 
   if (verboseLevel>2) {
-    G4cout << "\n New surface position " << *particleChange.GetPosition() / mm 
-     << " [mm]\n New wavevector direction " << reflectedKDir
+    G4cout << "New surface position " << *particleChange.GetPosition() / mm 
+     << " mm\n New wavevector direction " << reflectedKDir
 	   << "\n New momentum direction " << vdir << G4endl;
   }
 
@@ -331,7 +331,7 @@ GetSpecularVector(const G4ThreeVector& waveVector,
 
   if (verboseLevel>3) {
     G4cout << "GetSpecularVector:beforeLoop -> "
-      << ", stepLocalPos = " << stepLocalPos / mm << " [mm]"
+      << ", stepLocalPos = " << stepLocalPos / mm << " mm"
       << ", reflectedKDir = " << reflectedKDir
       << ", newNorm = " << newNorm
       << ", kPerpMag (newNorm dot reflectedKDir) = " << kPerpMag
@@ -410,8 +410,8 @@ GetSpecularVector(const G4ThreeVector& waveVector,
       G4cout << " "
        << "GetSpecularVector:insideLoop -> "
        << "attempts = " << nAttempts
-       << ", oldstepLocalPos = " << oldstepLocalPos / mm << " [mm]"
-       << ", stepLocalPos = " << stepLocalPos / mm << " [mm]"
+       << ", oldstepLocalPos = " << oldstepLocalPos / mm << " mm"
+       << ", stepLocalPos = " << stepLocalPos / mm << " mm"
        << ", oldNorm = " << oldNorm
        << ", newNorm = " << newNorm
        << ", kPerpMag = " << kPerpMag
@@ -431,9 +431,7 @@ GetSpecularVector(const G4ThreeVector& waveVector,
                                      GetGlobalPosition(stepLocalPos))) {
     if (verboseLevel) {
       G4cout << (GetProcessName()+"::GetSpecularVector").c_str()
-        << ": Phonon displacement failed after " << nAttempts - 1 << " attempts. "
-        << "Doing diffuse reflection at surface point: " << surfacePoint / mm
-        << " [mm]" << G4endl;
+        << ": Phonon displacement failed after " << nAttempts - 1 << " attempts. " << G4endl
     }
 
     // reflectedKDir and stepLocalPos will be in global coordinates
@@ -452,8 +450,8 @@ GetSpecularVector(const G4ThreeVector& waveVector,
       << ": nAttempts = " << nAttempts
       << ", waveVector = " << waveVector
       << ", reflectedKDir = " << reflectedKDir
-      << ", initialGlobalPostion = " << surfacePoint / mm << " [mm]"
-      << ", finalGlobalPosition = " << stepLocalPos / mm << " [mm]" << G4endl;
+      << ", initialGlobalPostion = " << surfacePoint / mm << " mm"
+      << ", finalGlobalPosition = " << stepLocalPos / mm << " mm" << G4endl;
   }
 
   delete solidUtils;

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -430,7 +430,9 @@ GetSpecularVector(const G4ThreeVector& waveVector,
   if (!G4CMP::PhononVelocityIsInward(theLattice, mode, reflectedKDir, newNorm,
                                      GetGlobalPosition(stepLocalPos))) {
     if (verboseLevel) {
-      G4cout << (GetProcessName()+"::GetSpecularVector").c_str()<< G4endl
+      G4cout << GetProcessName() << "::GetSpecularVector"
+        << ": Phonon displacement failed after " << nAttempts - 1 << " attempts. "
+        << "Doing diffuse reflection at surface point: " << surfacePoint / mm << " mm" << G4endl;
     }
 
     // reflectedKDir and stepLocalPos will be in global coordinates

--- a/library/src/G4CMPSolidUtils.cc
+++ b/library/src/G4CMPSolidUtils.cc
@@ -6,17 +6,19 @@
 /// \file library/src/G4PhononReflection.cc
 /// \brief This class contains custom utilities for G4VSolids that are not
 /// directly included in the G4VSolid class. Some example of utilites are:
-/// 1) Adjusting a position to the nearest surface point without the surface normal.
+/// 1) Adjusting a position to the nearest surface point without the surface
+///    normal.
 /// 2) Adjusting a particle to the nearest edge along the surface.
 /// 3) Reflecting a tangent vector against a "hard" edge.
 ///
-/// The user will need to create this class directly with a G4VSolid (and transform) or
-/// a touchable. If the transform or touchable is not provided, an indentity transform is
-/// used.
+/// The user will need to create this class directly with a G4VSolid (and
+/// transform) or a touchable. If the transform or touchable is not provided,
+/// an indentity transform is used.
 ///
-/// Note: All coordinates/vectors passed into functions must be in the global coordinate system.
-/// If a global-to-local transform is supplied, the input coordinates and vectors, and any output
-/// results, will be in the coordinate system of that transform.
+/// Note: All coordinates/vectors passed into functions must be in the global
+/// coordinate system. If a global-to-local transform is supplied, the input
+/// coordinates and vectors, and any output results, will be in the coordinate
+/// system of that transform.
 //
 // $Id$
 //
@@ -56,7 +58,8 @@ G4CMPSolidUtils::G4CMPSolidUtils(const G4VSolid* solid,
 G4CMPSolidUtils::G4CMPSolidUtils(const G4VTouchable* touch, G4int verbose,
                                  const G4String& vLabel)
   : theSolid(touch->GetSolid()),
-    theTransform(G4AffineTransform(touch->GetRotation(), touch->GetTranslation())),
+    theTransform(G4AffineTransform(touch->GetRotation(),
+				   touch->GetTranslation())),
     verboseLevel(verbose), verboseLabel(vLabel) {;}
 
 
@@ -223,10 +226,10 @@ AdjustToClosestSurfacePoint(G4ThreeVector& pos) const {
   if (theSolid->Inside(GetLocalPosition(pos + optDir)) == kSurface) {
     pos += optDir;
   } else {
-    if (verboseLevel) {
+    if (verboseLevel>2) {
       G4cout << verboseLabel << "::AdjustToClosestSurfacePoint"
-      << ": Surface point not found from initial position "
-      << pos << G4endl;
+	     << ": Surface point not found from initial position "
+	     << pos << G4endl;
     }
     pos.set(kInfinity,kInfinity,kInfinity);
   }
@@ -252,10 +255,11 @@ void G4CMPSolidUtils::AdjustToClosestSurfacePoint(G4ThreeVector& pos,
   G4double surfAdjust = GetDistanceToSolid(pos, dir);
   pos += surfAdjust * dir;
 
-  if (theSolid->Inside(GetLocalPosition(pos)) != kSurface && verboseLevel) {
+  if (theSolid->Inside(GetLocalPosition(pos)) != kSurface && verboseLevel>2) {
     G4cout << verboseLabel << "::AdjustToClosestSurfacePoint:"
-    << " WARNING: No surface found along " << dir
-    << ". Adjustment length: " << G4BestUnit(surfAdjust, "Length") << G4endl;
+	   << " WARNING: No surface found along " << dir
+	   << ". Adjustment length: " << G4BestUnit(surfAdjust, "Length")
+	   << G4endl;
   }
 }
 
@@ -298,11 +302,11 @@ AdjustToEdgePosition(const G4ThreeVector& vTan,
     else high = mid; // Move in
   }
 
-  if (verboseLevel > 1) {
+  if (verboseLevel>2) {
     G4cout << verboseLabel << "::AdjustToEdgePosition"
-      << ": initialPos = " << originalPos
-      << ", vTan = " << vTan
-      << ", finalPos = " << pos << G4endl;
+	   << ": initialPos = " << originalPos
+	   << ", vTan = " << vTan
+	   << ", finalPos = " << pos << G4endl;
   }
 }
 
@@ -344,15 +348,15 @@ ReflectAgainstEdge(G4ThreeVector& vTan, const G4ThreeVector& pos,
     vTan -= 2*((vTan * refNorm) * refNorm);
   }
 
-  if (verboseLevel > 1) {
+  if (verboseLevel>2) {
     G4cout << verboseLabel << "::ReflectAgainstEdge"
-      << ": pos = " << pos
-      << ", vTan_0 = " << vTan - 2*((vTan * -refNorm) * -refNorm)
-      << ", edgeVector = " << edgeVec
-      << ", refNorm = " << refNorm
-      << ", norm1 = " << norm1
-      << ", norm2 = " << norm2
-      << ", vTan_f = " << vTan << G4endl;
+	   << ": pos = " << pos
+	   << ", vTan_0 = " << vTan - 2*((vTan * -refNorm) * -refNorm)
+	   << ", edgeVector = " << edgeVec
+	   << ", refNorm = " << refNorm
+	   << ", norm1 = " << norm1
+	   << ", norm2 = " << norm2
+	   << ", vTan_f = " << vTan << G4endl;
   }
 
   TransformToGlobalDirection(vTan);
@@ -382,11 +386,11 @@ void G4CMPSolidUtils::AdjustOffFlats(G4ThreeVector& pos, G4ThreeVector& vTan,
     G4double vTanMag = vTan.mag();
     (vTan -= surfNorm * (vTan * surfNorm)).setMag(vTanMag);
 
-    if (verboseLevel > 2) {
+    if (verboseLevel>2) {
       G4cout << verboseLabel << "::AdjustOffFlats"
-        << ": Tangent vector: " << originalV
-        << " is not orthogonal to surface normal: " << surfNorm
-        << ". New Tangent vector: " << vTan << G4endl;
+	     << ": Tangent vector: " << originalV
+	     << " is not orthogonal to surface normal: " << surfNorm
+	     << ". New Tangent vector: " << vTan << G4endl;
     }
   }
 
@@ -399,15 +403,15 @@ void G4CMPSolidUtils::AdjustOffFlats(G4ThreeVector& pos, G4ThreeVector& vTan,
   // Adjust to surface
   localTrial -= surfAdjust * GetLocalDirection(surfNorm);
 
-  if (verboseLevel > 1) {
+  if (verboseLevel>2) {
     G4cout << verboseLabel << "::AdjustOffFlats"
-      << ": Original Position = " << originalPos
-      << ", Final Position = " << pos
-      << ", Step Direction = " << vTan
-      << ", Surface Normal = " << surfNorm
-      << ", Surface Adjustment at pos = " << surfAdjust
-      << ", Skipper Step Size = " << flatStepSize / mm << " mm"
-      << ", Consecutive iterations count: " << count << G4endl;
+	   << ": Original Position = " << originalPos
+	   << ", Final Position = " << pos
+	   << ", Step Direction = " << vTan
+	   << ", Surface Normal = " << surfNorm
+	   << ", Surface Adjustment at pos = " << surfAdjust
+	   << ", Skipper Step Size = " << flatStepSize / mm << " mm"
+	   << ", Consecutive iterations count: " << count << G4endl;
   }
 
   // At a hard edge - reflect kTan and repeat


### PR DESCRIPTION
As is usual with algorithm development, we have added some very detailed diagnostic printouts to G4CMPPhononBoundaryProcess, BoundaryUtils, TrackLimiter, and elsewhere. Before we close [G4CMP-317](https://jira.slac.stanford.edu/browse/G4CMP-317) and merge it only develop, we should ensure that all of those messages are protected within if (verboseLevel...) blocks.

The more detailed the output, the higher the level of verbosity should be needed to print it. Conversely, high level "information" messages should be visible with any verbosity.