### PR TITLE
Merge 483 to 317

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,7 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
-2025-05-09  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-05-10  G4CMP-317 : Implement surface 'displacement' for phonon reflection.
+2025-05-10  G4CMP-483 : Ensure backwards compatibility for vector utilities.
 2025-05-09  G4CMP-480 : Fix coordinate transforms for correct k->Vg mapping.
 2025-05-07  G4CMP-471 : Ensure that diagnostics are hidden with appropriate
                         verbosity levels.

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -20,7 +20,7 @@
 // 20250130  G4CMP-453 -- Add utilities for getting current track and touchable
 // 20250422  G4CMP-468 -- Add position argument to PhononVelocityIsInward
 // 20250423  G4CMP-468 -- Add function to get diffuse reflection vector
-// 20250510  G4CMP-483 -- Allow backwards compatibility for vector utilities.
+// 20250510  G4CMP-483 -- Ensure backwards compatibility for vector utilities.
 
 #ifndef G4CMPUtils_hh
 #define G4CMPUtils_hh 1

--- a/library/include/G4CMPUtils.hh
+++ b/library/include/G4CMPUtils.hh
@@ -20,6 +20,7 @@
 // 20250130  G4CMP-453 -- Add utilities for getting current track and touchable
 // 20250422  G4CMP-468 -- Add position argument to PhononVelocityIsInward
 // 20250423  G4CMP-468 -- Add function to get diffuse reflection vector
+// 20250510  G4CMP-483 -- Allow backwards compatibility for vector utilities.
 
 #ifndef G4CMPUtils_hh
 #define G4CMPUtils_hh 1
@@ -86,12 +87,17 @@ namespace G4CMP {
 
   // Phonons reflect difusively from surfaces.
   G4ThreeVector GetLambertianVector(const G4LatticePhysical* theLattice,
+                                    const G4ThreeVector& surfNorm, G4int mode);
+  G4ThreeVector GetLambertianVector(const G4LatticePhysical* theLattice,
                                     const G4ThreeVector& surfNorm, G4int mode,
                                     const G4ThreeVector& surfPoint);
   G4ThreeVector LambertReflection(const G4ThreeVector& surfNorm);
 
   // Test that a phonon's wave vector relates to an inward velocity.
   // waveVector, surfNorm, and surfacePos need to be in global coordinates
+  G4bool PhononVelocityIsInward(const G4LatticePhysical* lattice, G4int mode,
+                                const G4ThreeVector& waveVector,
+                                const G4ThreeVector& surfNorm);
   G4bool PhononVelocityIsInward(const G4LatticePhysical* lattice, G4int mode,
                                 const G4ThreeVector& waveVector,
                                 const G4ThreeVector& surfNorm,

--- a/library/src/G4CMPPhononBoundaryProcess.cc
+++ b/library/src/G4CMPPhononBoundaryProcess.cc
@@ -429,7 +429,7 @@ GetSpecularVector(const G4ThreeVector& waveVector,
   RotateToGlobalPosition(stepLocalPos);
 
   if (!G4CMP::PhononVelocityIsInward(theLattice, mode, reflectedKDir, newNorm,
-                                     GetGlobalPosition(stepLocalPos))) {
+                                     stepLocalPos)) {
     if (verboseLevel) {
       G4cerr << GetProcessName() << "::GetSpecularVector"
 	     << ": Phonon displacement failed after " << nAttempts - 1

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -20,7 +20,7 @@
 // 20250130  G4CMP-453 -- Apply coordinate rotations in PhononVelocityIsInward
 // 20250422  G4CMP-468 -- Add displaced point test to PhononVelocityIsInward.
 // 20250423  G4CMP-468 -- Add function to get diffuse reflection vector.
-// 20250510  G4CMP-483 -- Allow backwards compatibility for vector utilities.
+// 20250510  G4CMP-483 -- Ensure backwards compatibility for vector utilities.
 
 #include "G4CMPUtils.hh"
 #include "G4CMPConfigManager.hh"

--- a/library/src/G4CMPUtils.cc
+++ b/library/src/G4CMPUtils.cc
@@ -20,6 +20,7 @@
 // 20250130  G4CMP-453 -- Apply coordinate rotations in PhononVelocityIsInward
 // 20250422  G4CMP-468 -- Add displaced point test to PhononVelocityIsInward.
 // 20250423  G4CMP-468 -- Add function to get diffuse reflection vector.
+// 20250510  G4CMP-483 -- Allow backwards compatibility for vector utilities.
 
 #include "G4CMPUtils.hh"
 #include "G4CMPConfigManager.hh"
@@ -213,6 +214,13 @@ void G4CMP::FillHit(const G4Step* step, G4CMPElectrodeHit* hit) {
 
 G4ThreeVector
 G4CMP::GetLambertianVector(const G4LatticePhysical* theLattice,
+			   const G4ThreeVector& surfNorm, G4int mode) {
+  const G4ThreeVector surfPoint = GetCurrentTrack()->GetPosition();
+  return GetLambertianVector(theLattice, surfNorm, mode, surfPoint);
+}
+
+G4ThreeVector
+G4CMP::GetLambertianVector(const G4LatticePhysical* theLattice,
 			   const G4ThreeVector& surfNorm, G4int mode,
 			   const G4ThreeVector& surfPoint) {
   G4ThreeVector reflectedKDir;
@@ -240,6 +248,14 @@ G4ThreeVector G4CMP::LambertReflection(const G4ThreeVector& surfNorm) {
 
 // Check that phonon is properly directed from the volume surface
 // waveVector and surfNorm need to be in global coordinates
+
+G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
+                                     G4int mode,
+                                     const G4ThreeVector& waveVector,
+                                     const G4ThreeVector& surfNorm) {
+  const G4ThreeVector surfacePos = GetCurrentTrack()->GetPosition();
+  return PhononVelocityIsInward(lattice, mode, waveVector, surfNorm, surfacePos);
+}
 
 G4bool G4CMP::PhononVelocityIsInward(const G4LatticePhysical* lattice,
                                      G4int mode,


### PR DESCRIPTION
This ensures backwards compatibility for the vector utilities that were created during the 468 work.