### PR TITLE
Merge G4CMP-491 to develop

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,8 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2025-07-11  G4CMP-491 : Turn off phonon surface displacement loop by default.
+
 2025-07-10  g4cmp-V09-07-01 Support generating Doxygen class info Web pages.
 2025-07-10  G4CMP-492 : Add Doxyfile to support generate Doxygen class info.
 

--- a/library/src/G4CMPConfigManager.cc
+++ b/library/src/G4CMPConfigManager.cc
@@ -46,6 +46,7 @@
 // 20250212  G4CMP-457: Add short names for empirical Lindhard NIEL.
 // 20250422  G4CMP-472: Adjust order of data members to avoid compiler warnings.
 // 20250325  G4CMP-463: Add parameter for phonon surface step size & limit.
+// 20250711  G4CMP-491: Turn off phonon surface displacement loop by default.
 
 
 #include "G4CMPConfigManager.hh"
@@ -91,7 +92,7 @@ G4CMPConfigManager::G4CMPConfigManager()
     ehBounces(getenv("G4CMP_EH_BOUNCES")?atoi(getenv("G4CMP_EH_BOUNCES")):1),
     pBounces(getenv("G4CMP_PHON_BOUNCES")?atoi(getenv("G4CMP_PHON_BOUNCES")):100),
     maxLukePhonons(getenv("G4MP_MAX_LUKE")?atoi(getenv("G4MP_MAX_LUKE")):-1),
-    pSurfStepLimit(getenv("G4CMP_PHON_SURFLIMIT")?strtod(getenv("G4CMP_PHON_SURFLIMIT"),0):5000),
+    pSurfStepLimit(getenv("G4CMP_PHON_SURFLIMIT")?strtod(getenv("G4CMP_PHON_SURFLIMIT"),0):-1),
     LatticeDir(getenv("G4LATTICEDATA")?getenv("G4LATTICEDATA"):"./CrystalMaps"),
     IVRateModel(getenv("G4CMP_IV_RATE_MODEL")?getenv("G4CMP_IV_RATE_MODEL"):""),
     lukeFilename(getenv("G4CMP_LUKE_FILE")?getenv("G4CMP_LUKE_FILE"):"LukePhononEnergies"),


### PR DESCRIPTION
This branch sets the default value for the step limit for the phonon surface displacement loop (G4CMP-317) to -1. This effectively backs out the 317 code, but keeps all the additional features and necessary changes.

If the step limit is defined as > 0, the surface displacement loop is used for failed specular reflections. Otherwise, a failed specular reflection simply results in a diffuse reflection.