### PR TITLE
G4cmp-493 into G4CMP-404

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -7,7 +7,8 @@ Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
 [ Modifications included on branch G4CMP-404, put subtask tags below it: ]
-2025-05-27  G4CMP-404 : Improve charge carriers-phonons scattering.
+2025-07-28  G4CMP-404 : Improve charge carriers-phonons scattering.
+2025-07-28  G4CMP-493 : Add average speed of sound.
 2025-05-27  G4CMP-485 : Rename "IVRate" model name to "Matrix".
 2025-05-02  G4CMP-120 : IV scattering process should include kinematic effects.
 2024-09-27  G4CMP-429 : Add IV order and # final valleys to config.txt.

--- a/library/include/G4LatticeLogical.hh
+++ b/library/include/G4LatticeLogical.hh
@@ -190,6 +190,7 @@ public:
   void SetFanoFactor(G4double f) { fFanoFactor = f; }
   void SetSoundSpeed(G4double v) { fVSound = v; }
   void SetTransverseSoundSpeed(G4double v) { fVTrans = v; }
+  void SetAverageSoundSpeed(G4double v) { fVSoundAverage = v; }
   void SetHoleScatter(G4double l0) { fL0_h = l0; }
   void SetHoleMass(G4double hmass) { fHoleMass = hmass; }
   void SetElectronScatter(G4double l0) { fL0_e = l0; }
@@ -201,6 +202,7 @@ public:
   G4double GetFanoFactor() const                { return fFanoFactor; }
   G4double GetSoundSpeed() const                { return fVSound; }
   G4double GetTransverseSoundSpeed() const      { return fVTrans; }
+  G4double GetAverageSoundSpeed() const         { return fVSoundAverage; }
   G4double GetHoleScatter() const               { return fL0_h; }
   G4double GetHoleMass() const                  { return fHoleMass; }
   G4double GetElectronScatter() const           { return fL0_e; }
@@ -216,6 +218,9 @@ public:
     
   // Compute "l0" for electron and hole
   G4double ComputeL0(G4bool IsElec);
+
+  // Compute average speed of sound
+  G4double ComputeAverageSoundSpeed();
 
   G4ThreeVector RotateToValley(G4int iv, const G4ThreeVector& v) const;
   G4ThreeVector RotateFromValley(G4int iv, const G4ThreeVector& v) const;
@@ -365,6 +370,7 @@ private:
 
   G4double fVSound;	// Speed of sound (longitudinal phonon)
   G4double fVTrans;	// Speed of sound (transverse phonon)
+  G4double fVSoundAverage;	// Speed of sound (average over phonon DOS)
   G4double fL0_e;	// Scattering length for electrons
   G4double fL0_h;	// Scattering length for holes
 

--- a/library/include/G4LatticePhysical.hh
+++ b/library/include/G4LatticePhysical.hh
@@ -141,6 +141,7 @@ public:
   G4double GetFanoFactor() const      { return fLattice->GetFanoFactor(); }
   G4double GetSoundSpeed() const      { return fLattice->GetSoundSpeed(); }
   G4double GetTransverseSoundSpeed() const { return fLattice->GetTransverseSoundSpeed(); }
+  G4double GetAverageSoundSpeed() const { return fLattice->GetAverageSoundSpeed(); }
   G4double GetElectronScatter() const { return fLattice->GetElectronScatter(); }
   G4double GetHoleScatter() const     { return fLattice->GetHoleScatter(); }
 

--- a/library/src/G4LatticeLogical.cc
+++ b/library/src/G4LatticeLogical.cc
@@ -958,6 +958,16 @@ G4double G4LatticeLogical::ComputeL0(G4bool IsElec) {
   return l0;
 }
 
+
+// Compute average speed of sound based on phonon DOS
+
+G4double G4LatticeLogical::ComputeAverageSoundSpeed() {
+
+  G4double AverageSoundSpeed = fLDOS*fVSound + (fSTDOS+fFTDOS)*fVTrans;
+
+  return AverageSoundSpeed;
+}
+
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
 // Set Debye energy for phonon partitioning from alternative parameters

--- a/library/src/G4LatticeReader.cc
+++ b/library/src/G4LatticeReader.cc
@@ -210,7 +210,8 @@ G4bool G4LatticeReader::ProcessValue(const G4String& name) {
   else if (name == "neutdens")   pLattice->SetImpurities(fValue*ProcessUnits("Volume"));
   else if (name == "epsilon")    pLattice->SetPermittivity(fValue);
   else if (name == "vsound")     pLattice->SetSoundSpeed(fValue*ProcessUnits("Velocity"));
-  else if (name == "vtrans")     pLattice->SetTransverseSoundSpeed(fValue*ProcessUnits("Velocity"));
+  else if (name == "vtrans")     {pLattice->SetTransverseSoundSpeed(fValue*ProcessUnits("Velocity"));
+                                  pLattice->SetAverageSoundSpeed(pLattice->ComputeAverageSoundSpeed()); }
   else if (name == "escat")      pLattice->SetElectronScatter(fValue*ProcessUnits("Length"));
   else if (name == "l0_e")       pLattice->SetElectronScatter(fValue*ProcessUnits("Length"));
   else if (name == "hscat")      pLattice->SetHoleScatter(fValue*ProcessUnits("Length"));


### PR DESCRIPTION
I have created a function in G4LatticeLogical called ComputeAverageSoundSpeed() that computes the average speed of sound weighted by phonon DOS. For example, this average is calculated as : 

G4double AverageSoundSpeed = fLDOS*fVSound + (fSTDOS+fFTDOS)*fVTrans;

I think it's ready to be merged into G4CMP-404!