### PR TITLE
G4CMP 478

### DIFF
--- a/ChangeHistory
+++ b/ChangeHistory
@@ -6,6 +6,7 @@ Releases are tagged on the 'master' branch as "g4cmp-Vxx-yy-zz".
 Features and bug fixes are tagged on the 'develop' branch using the JIRA
 ticket identifier, "G4CMP-nnn", or using the GitHub pull request, "PR-nn".
 
+2025-09-29  G4CMP-478 : Lowered G4CMPDriftTrapIonization minimum energy.
 2025-09-25  G4CMP-505 : Fix Confluence link in README.md.
 2025-09-12  G4CMP-504 : Add tutorial for computing phonon DOS in new materials.
 

--- a/library/src/G4CMPDriftTrapIonization.cc
+++ b/library/src/G4CMPDriftTrapIonization.cc
@@ -7,6 +7,7 @@
 // 20200426  G4CMP-196: Change name to TrapIonization, specify beam and trap
 //		particle types
 // 20200604  G4CMP-208: Comment out unused function arguments
+// 20250929  G4CMP-478: Change secondary minimal energy from 1e-3 to 1e-6
 
 #include "G4CMPDriftTrapIonization.hh"
 #include "G4CMPConfigManager.hh"
@@ -95,7 +96,7 @@ G4CMPDriftTrapIonization::PostStepDoIt(const G4Track& aTrack,
 
   // Create secondary with minimal energy, assuming no momentum transfer
   G4Track* knockon = G4CMP::CreateSecondary(aTrack, trapType,
-					    G4RandomDirection(), 1e-3*eV);
+					    G4RandomDirection(), 1e-6*eV);
   aParticleChange.AddSecondary(knockon);
 
   ClearNumberOfInteractionLengthLeft();		// All processes should do this!


### PR DESCRIPTION
Lowered the minimum energy for secondaries produced by G4CMPDriftTrapIonization from 1e-3 to 1e-6.  Geant4 requires some energy but need to preserve energy/momentum conservation.

Before
<img width="570" height="457" alt="Before" src="https://github.com/user-attachments/assets/6b66880c-d973-4a3b-aba4-63f79e550c4b" />
After
<img width="570" height="457" alt="After" src="https://github.com/user-attachments/assets/9bf75b48-dcad-46d3-ab9e-2417ec735598" />
